### PR TITLE
Error handling, a graphite event, and reduced logspam.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ The rollout will then begin:
 * after a number of hosts have completed their work, the rollout can pause to
   allow [sanity checking][1] before continuing on (`--pauseafter`)
 
+If configured, graphite will be sent a metric of the form
+`events.deploy.{component}` for each component deployed.
+
 The rolling pin also features integration with [Harold][2].
 
 See [example.ini](example.ini) for configuration instructions.

--- a/example.ini
+++ b/example.ini
@@ -42,6 +42,11 @@ base-url =
 ; secret token for communication with harold
 secret =
 
+[graphite]
+; if configured, an event will be sent to graphite when the deploy starts.
+; https://twistedmatrix.com/documents/14.0.0/core/howto/endpoints.html#clients
+endpoint =
+
 [aliases]
 ; glob patterns for aliasing groups of servers
 apps = app-* job-*

--- a/rollingpin/args.py
+++ b/rollingpin/args.py
@@ -114,6 +114,14 @@ def _add_flags(config, parser):
             dest="notify_harold",
         )
 
+    options_group.add_argument(
+        "-v", "--verbose",
+        action="store_true",
+        default=False,
+        help="spew verbose logging of command output to the console",
+        dest="verbose_logging",
+    )
+
 
 def _add_deploy_arguments(config, parser):
     deploy_group = parser.add_argument_group(
@@ -190,6 +198,9 @@ def construct_canonical_commandline(config, args):
 
     if config["harold"]["base-url"] and not args.notify_harold:
         arg_list.append("--no-harold")
+
+    if args.verbose_logging:
+        arg_list.append("--verbose")
 
     if args.components:
         arg_list.append("-d")

--- a/rollingpin/deploy.py
+++ b/rollingpin/deploy.py
@@ -100,7 +100,10 @@ class Deployer(object):
 
     @inlineCallbacks
     def run_deploy(self, hosts, components, commands):
-        self.transport.initialize()
+        try:
+            self.transport.initialize()
+        except TransportError as e:
+            raise DeployError("could not initialize transport: %s" % e)
 
         def signal_handler(sig, _):
             reason = SIGNAL_MESSAGES[sig]

--- a/rollingpin/frontends.py
+++ b/rollingpin/frontends.py
@@ -61,15 +61,18 @@ class HostFormatter(logging.Formatter):
 
 
 class HeadlessFrontend(object):
-    def __init__(self, event_bus, hosts):
+    def __init__(self, event_bus, hosts, verbose_logging):
         longest_hostname = max(len(host) for host in hosts)
 
         formatter = HostFormatter(longest_hostname)
         handler = logging.StreamHandler()
         handler.setFormatter(formatter)
+        if verbose_logging:
+            handler.setLevel(logging.DEBUG)
+        else:
+            handler.setLevel(logging.INFO)
 
         root = logging.getLogger()
-        root.setLevel(logging.DEBUG)
         root.addHandler(handler)
 
         self.host_results = dict.fromkeys(hosts, None)
@@ -166,8 +169,8 @@ class StdioListener(Protocol):
 
 
 class HeadfulFrontend(HeadlessFrontend):
-    def __init__(self, event_bus, hosts, pause_after):
-        HeadlessFrontend.__init__(self, event_bus, hosts)
+    def __init__(self, event_bus, hosts, verbose_logging, pause_after):
+        HeadlessFrontend.__init__(self, event_bus, hosts, verbose_logging)
 
         self.console_input = StdioListener()
         StandardIO(self.console_input)

--- a/rollingpin/graphite.py
+++ b/rollingpin/graphite.py
@@ -1,0 +1,36 @@
+import time
+
+from twisted.internet import endpoints, reactor
+from twisted.internet.protocol import Protocol
+
+
+class OneShotMessageWriter(Protocol):
+    def __init__(self, message):
+        self.message = message
+
+    def connectionMade(self):
+        self.transport.write(self.message)
+        self.transport.loseConnection()
+
+
+class GraphiteNotifier(object):
+    def __init__(self, config, components):
+        self.endpoint_config = config["graphite"]["endpoint"]
+        self.components = components
+
+    def on_deploy_start(self):
+        now = int(time.time())
+        events = ("events.deploy.%s %d %d\n" % (component, 1, now)
+            for component in self.components)
+        message = "".join(events)
+        protocol = OneShotMessageWriter(message)
+
+        endpoint = endpoints.clientFromString(reactor, self.endpoint_config)
+        endpoints.connectProtocol(endpoint, protocol)
+
+
+def enable_graphite_notifications(config, event_bus, components):
+    notifier = GraphiteNotifier(config, components)
+    event_bus.register({
+        "deploy.begin": notifier.on_deploy_start,
+    })

--- a/rollingpin/log.py
+++ b/rollingpin/log.py
@@ -26,9 +26,12 @@ def log_to_file(config, word):
     log_path = os.path.join(config["deploy"]["log-directory"], log_name)
     handler = logging.FileHandler(log_path, mode="w")
     handler.setFormatter(formatter)
+    handler.setLevel(logging.DEBUG)
 
     root = logging.getLogger()
-    root.setLevel(logging.DEBUG)
+    # the default level for the root logger is WARNING, changing it to
+    # NOTSET allows handlers to choose for themselves their verbosity
+    root.setLevel(logging.NOTSET)
     root.addHandler(handler)
 
     return log_path

--- a/rollingpin/main.py
+++ b/rollingpin/main.py
@@ -145,9 +145,9 @@ def _main(reactor, *raw_args):
             args.original, log_path)
 
     if os.isatty(sys.stdout.fileno()):
-        HeadfulFrontend(event_bus, hosts, args.pause_after)
+        HeadfulFrontend(event_bus, hosts, args.verbose_logging, args.pause_after)
     else:
-        HeadlessFrontend(event_bus, hosts)
+        HeadlessFrontend(event_bus, hosts, args.verbose_logging)
 
     # execute
     if args.list_hosts:

--- a/rollingpin/main.py
+++ b/rollingpin/main.py
@@ -6,7 +6,12 @@ from twisted.internet.defer import inlineCallbacks, returnValue
 from twisted.internet.task import react
 
 from .args import make_arg_parser, construct_canonical_commandline
-from .config import coerce_and_validate_config, ConfigurationError, Option
+from .config import (
+    coerce_and_validate_config,
+    ConfigurationError,
+    Option,
+    OptionalSection,
+)
 from .deploy import Deployer, DeployError
 from .eventbus import EventBus
 from .frontends import HeadlessFrontend, HeadfulFrontend
@@ -33,10 +38,10 @@ CONFIG_SPEC = {
         "default-parallel": Option(int),
     },
 
-    "harold": {
+    "harold": OptionalSection({
         "base-url": Option(str, default=None),
         "hmac-secret": Option(str, default=None),
-    },
+    }),
 
     "hostsource": {
         "provider": Option(str),

--- a/rollingpin/main.py
+++ b/rollingpin/main.py
@@ -24,6 +24,7 @@ from .hostlist import (
     restrict_hostlist,
 )
 from .hostsources import HostSourceError
+from .graphite import enable_graphite_notifications
 from .log import log_to_file
 from .providers import get_provider, UnknownProviderError
 from .utils import random_word
@@ -41,6 +42,10 @@ CONFIG_SPEC = {
     "harold": OptionalSection({
         "base-url": Option(str, default=None),
         "hmac-secret": Option(str, default=None),
+    }),
+
+    "graphite": OptionalSection({
+        "endpoint": Option(str, default=None),
     }),
 
     "hostsource": {
@@ -148,6 +153,9 @@ def _main(reactor, *raw_args):
         enable_harold_notifications(
             word, config, event_bus, hosts,
             args.original, log_path)
+
+    if config["graphite"]["endpoint"]:
+        enable_graphite_notifications(config, event_bus, args.components)
 
     if os.isatty(sys.stdout.fileno()):
         HeadfulFrontend(event_bus, hosts, args.verbose_logging, args.pause_after)

--- a/rollingpin/transports/ssh.py
+++ b/rollingpin/transports/ssh.py
@@ -24,6 +24,7 @@ from ..config import Option
 from ..transports import (
     Transport,
     TransportConnection,
+    TransportError,
     CommandFailed,
     ConnectionError,
 )
@@ -99,6 +100,11 @@ class _ConnectionFactory(ClientFactory):
         self.connection_ready.errback(reason)
 
 
+class BadKeyPassphraseError(TransportError):
+    def __init__(self):
+        TransportError.__init__(self, "bad passphrase for ssh key")
+
+
 def _load_key(filename):
     try:
         return Key.fromFile(filename)
@@ -112,6 +118,8 @@ def _load_key(filename):
                 return Key.fromFile(filename, passphrase=passphrase)
             except BadKeyError:
                 pass
+
+        raise BadKeyPassphraseError()
 
 
 class SshTransport(Transport):

--- a/tests/args.py
+++ b/tests/args.py
@@ -93,6 +93,19 @@ class TestArgumentParsing(unittest.TestCase):
         args = self.parser.parse_args(["-h", "a", "--no-harold"])
         self.assertFalse(args.notify_harold)
 
+    # -v / --verbose
+    def test_verbose_default(self):
+        args = self.parser.parse_args(["-h", "a"])
+        self.assertFalse(args.verbose_logging)
+
+    def test_verbose_flagged_short(self):
+        args = self.parser.parse_args(["-h", "a", "-v"])
+        self.assertTrue(args.verbose_logging)
+
+    def test_verbose_flagged_long(self):
+        args = self.parser.parse_args(["-h", "a", "--verbose"])
+        self.assertTrue(args.verbose_logging)
+
     # -d
     def test_empty_deploys(self):
         args = self.parser.parse_args(["-h", "a"])
@@ -237,3 +250,8 @@ class TestArgumentReconstruction(unittest.TestCase):
         args = self.parser.parse_args(["-h", "host", "-c", "cmd1", "-c", "cmd2"])
         canonical = construct_canonical_commandline(self.config, args)
         self.assertEqual("-h host --parallel=5 -c cmd1 -c cmd2", canonical)
+
+    def test_verbose(self):
+        args = self.parser.parse_args(["-h", "host", "-v"])
+        canonical = construct_canonical_commandline(self.config, args)
+        self.assertEqual("-h host --parallel=5 --verbose", canonical)

--- a/tests/config.py
+++ b/tests/config.py
@@ -87,3 +87,35 @@ class TestConfiguration(unittest.TestCase):
         errors = info.exception.errors
         self.assertEqual(len(errors), 1)
         self.assertIsInstance(errors[0], rollingpin.config.CoercionError)
+
+
+class TestOptionalSections(unittest.TestCase):
+    def test_bad_optional_section(self):
+        parser = ConfigParser.ConfigParser()
+        with self.assertRaises(rollingpin.config.NoDefaultInOptionalSection):
+            rollingpin.config.coerce_and_validate_config(parser, {
+                "optional-section": rollingpin.config.OptionalSection({
+                    "key": rollingpin.config.Option(int),
+                })
+            })
+
+    def test_optional_section_missing(self):
+        parser = ConfigParser.ConfigParser()
+        config = rollingpin.config.coerce_and_validate_config(parser, {
+            "optional-section": rollingpin.config.OptionalSection({
+                "key": rollingpin.config.Option(int, default=3),
+            })
+        })
+        self.assertEqual(config["optional-section"]["key"], 3)
+
+    def test_optional_section_present(self):
+        parser = make_configparser("""
+        [optional-section]
+        key = value
+        """)
+        config = rollingpin.config.coerce_and_validate_config(parser, {
+            "optional-section": rollingpin.config.OptionalSection({
+                "key": rollingpin.config.Option(str, default=None),
+            })
+        })
+        self.assertEqual(config["optional-section"]["key"], "value")


### PR DESCRIPTION
This is a small batch of updates for rolling pin:

* reduce logspam by not printing the output of individual deploy commands from the servers
* handle bad ssh key passphrases better (#1)
* send a metric to graphite when deploying (#2)
* minor config syntax improvement

:eyeglasses: @Deimos @umbrae @xiongchiamiov 