### PR TITLE
Allow components to use different build servers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To roll stuff out, select a group of hosts to affect:
 
 And what commands you'd like to run:
 
-* components to deploy get built on a central build server then deployed to
+* components to deploy get built on configurable build servers then deployed to
   individual hosts (`-d`)
 * restart services (`-r`)
 * arbitrary other commands may be specified as long as the remote end knows how

--- a/example-deploy.py
+++ b/example-deploy.py
@@ -21,7 +21,7 @@ def run_and_capture(*argv):
 
 
 def synchronize(*components):
-    """Synchronize the code repistories with upstreams.
+    """Synchronize the code repositories with upstreams.
 
     This is called once on the code host with a list of all components to
     synchronize. The script should fetch from upstream remotes, sync with a SCM

--- a/example.ini
+++ b/example.ini
@@ -20,6 +20,7 @@ build-host = build-01
 ; the other built in provider is "autoscaler". additional providers may be
 ; implemented and discovered with the pkg_resources entry points system.
 provider = mock
+hosts = example-01
 
 [transport]
 ; the other built in provider is "mock". additional providers may be

--- a/example.ini
+++ b/example.ini
@@ -13,8 +13,8 @@ default-sleeptime = 0
 ; default value for the --parallel parameter. the maximum number of servers
 ; that will be acted upon at the same time.
 default-parallel = 2
-; the host on which to perform component builds before deploying
-build-host = build-01
+; the host on which the local copy of source code is maintained
+code-host = code-01
 
 [hostsource]
 ; the other built in provider is "autoscaler". additional providers may be

--- a/rollingpin/deploy.py
+++ b/rollingpin/deploy.py
@@ -139,7 +139,7 @@ class Deployer(object):
                         if build_host:
                             by_buildhost[build_host].append(component_ref)
                         else:
-                            # no build host means we just pass the build token
+                            # no build host means we just pass the sync token
                             # straight through as a deploy token
                             deploy_command.append(component_ref)
 
@@ -151,6 +151,8 @@ class Deployer(object):
                             build_host, [build_command])
 
                         for ref in build_refs:
+                            component, at, sync_token = ref.partition("@")
+                            assert at == "@"
                             try:
                                 deploy_ref = component + "@" + tokens[ref]
                             except KeyError:

--- a/rollingpin/hostsources/mock.py
+++ b/rollingpin/hostsources/mock.py
@@ -2,18 +2,22 @@ import random
 
 from twisted.internet.defer import succeed
 
+from ..config import Option
 from ..hostsources import HostSource
 
 
 class MockHostSource(HostSource):
+    config_spec = {
+        "hostsource": {
+            "hosts": Option(str),
+        },
+    }
+
     def __init__(self, config):
-        pass
+        self.hosts = config["hostsource"]["hosts"].split()
 
     def get_hosts(self):
-        return succeed(
-            ["host-%02d" % i for i in xrange(1, 270)] +
-            ["otherhost-%02d" % i for i in xrange(1, 5)]
-        )
+        return succeed(self.hosts)
 
     def should_be_alive(self, host):
         return succeed(random.choice((True, True, True, False)))

--- a/rollingpin/main.py
+++ b/rollingpin/main.py
@@ -34,7 +34,7 @@ CONFIG_SPEC = {
     "deploy": {
         "log-directory": Option(str),
         "wordlist": Option(str),
-        "build-host": Option(str),
+        "code-host": Option(str),
         "default-sleeptime": Option(int),
         "default-parallel": Option(int),
     },


### PR DESCRIPTION
This adds an extra layer of indirection to the pre-deploy process
intended to allow greater flexibility in the build process. The process
now looks like:

* synchronize: update our local copy of the code to the latest version.
  for each component, synchronize can return a buildhost to use for that
  component's pre-deploy build process.

* build: any components that specified a build host will be built on the
  specified host.  each component may have a different build host
  allowing for greater flexibility if different projects have different
  dependencies.

* deploy: for each host, deploy the components either with their code
  revision ID as returned by synchronize, or if a build host were
  specified the build token returned from the build process.

(also: bonus change to allow mock hostsource to be more configurable)

:eyeglasses: @bsimpson63 @umbrae 

cc: @rram @jdubs @kjoconnor