### PR TITLE
Decode UTF8 in log formatters

### DIFF
--- a/rollingpin/frontends.py
+++ b/rollingpin/frontends.py
@@ -53,7 +53,7 @@ class HostFormatter(logging.Formatter):
         logging.Formatter.__init__(self)
 
     def format(self, record):
-        formatted = logging.Formatter.format(self, record)
+        formatted = logging.Formatter.format(self, record).decode("utf8")
 
         if hasattr(record, "host"):
             formatted = (self.hostname_format % record.host) + formatted

--- a/rollingpin/log.py
+++ b/rollingpin/log.py
@@ -8,7 +8,7 @@ class LogFormatter(logging.Formatter):
     converter = time.gmtime
 
     def format(self, record):
-        formatted = logging.Formatter.format(self, record)
+        formatted = logging.Formatter.format(self, record).decode("utf8")
 
         if hasattr(record, "host"):
             formatted = ("[%10s]  " % record.host) + formatted


### PR DESCRIPTION
This prevents a crash when there's non-ASCII stuff in the logs. For
example, stuff like "65 μs".

(This was particularly noticeable in mweb deploys)

:eyeglasses: @dellis23 @Deimos 