### PR TITLE
Pass a host object around instead of just a string; use that to avoid DNS

### DIFF
--- a/example.ini
+++ b/example.ini
@@ -3,7 +3,7 @@
 
 [deploy]
 ; where to write logs for rollouts
-log-directory = /var/log/rollouts/
+log-directory = /tmp
 ; the full path to a file that contains a list of words one per line. used to
 ; generate a random "name" for the push.
 wordlist = /usr/share/dict/words
@@ -20,13 +20,13 @@ code-host = code-01
 ; the other built in provider is "autoscaler". additional providers may be
 ; implemented and discovered with the pkg_resources entry points system.
 provider = mock
-hosts = example-01
+hosts = app-01 app-02 app-03 job-01 job-02 uncool-01
 
 [transport]
-; the other built in provider is "mock". additional providers may be
-; implemented and discovered with the pkg_resources entry points system.
-; use ssh to talk to hosts
-provider = ssh
+; this is a simple testing provider
+provider = mock
+
+;;;; these are the options for the ssh provider
 ; username to log in with
 user = deploy
 ; key file to use. may (should) be password protected.
@@ -50,5 +50,5 @@ endpoint =
 
 [aliases]
 ; glob patterns for aliasing groups of servers
-apps = app-* job-*
+apps = app-* %(jobs)s
 jobs = job-*

--- a/rollingpin/frontends.py
+++ b/rollingpin/frontends.py
@@ -64,7 +64,7 @@ class HostFormatter(logging.Formatter):
 
 class HeadlessFrontend(object):
     def __init__(self, event_bus, hosts, verbose_logging):
-        longest_hostname = max(len(host) for host in hosts)
+        longest_hostname = max(len(host.name) for host in hosts)
 
         formatter = HostFormatter(longest_hostname)
         self.log_handler = logging.StreamHandler()
@@ -142,7 +142,7 @@ class HeadlessFrontend(object):
                    "hosts:" % len(warning_hosts))
             print "      ", " ".join(
                 colorize(host, Color.YELLOW)
-                for host in sorted_nicely(warning_hosts))
+                for host in sorted_nicely(host.name for host in warning_hosts))
 
         if by_result["error"]:
             error_hosts = by_result["error"]
@@ -150,7 +150,7 @@ class HeadlessFrontend(object):
                    "healthy hosts:" % len(error_hosts))
             print "      ", " ".join(
                 colorize(host, Color.RED)
-                for host in sorted_nicely(error_hosts))
+                for host in sorted_nicely(host.name for host in error_hosts))
 
         successful_hosts = len(by_result["success"])
         print "*** processed %d hosts successfully" % successful_hosts

--- a/rollingpin/hostsources/__init__.py
+++ b/rollingpin/hostsources/__init__.py
@@ -1,5 +1,15 @@
+import collections
+
+
 class HostSourceError(Exception):
     pass
+
+
+_Host = collections.namedtuple("_Host", "name address")
+class Host(_Host):
+    @classmethod
+    def from_hostname(cls, name):
+        return Host(name, name)
 
 
 class HostSource(object):

--- a/rollingpin/hostsources/mock.py
+++ b/rollingpin/hostsources/mock.py
@@ -3,7 +3,7 @@ import random
 from twisted.internet.defer import succeed
 
 from ..config import Option
-from ..hostsources import HostSource
+from ..hostsources import Host, HostSource
 
 
 class MockHostSource(HostSource):
@@ -17,7 +17,7 @@ class MockHostSource(HostSource):
         self.hosts = config["hostsource"]["hosts"].split()
 
     def get_hosts(self):
-        return succeed(self.hosts)
+        return succeed(Host(name, name + ".local") for name in self.hosts)
 
     def should_be_alive(self, host):
         return succeed(random.choice((True, True, True, False)))

--- a/rollingpin/main.py
+++ b/rollingpin/main.py
@@ -125,16 +125,19 @@ def _select_hosts(config, args):
         print_error("could not fetch host list: {}", e)
         sys.exit(1)
 
+    hosts_by_name = {host.name: host for host in all_hosts}
+    hostnames = hosts_by_name.keys()
+
     try:
-        aliases = resolve_aliases(config["aliases"], all_hosts)
-        full_hostlist = resolve_hostlist(args.host_refs, all_hosts, aliases)
+        aliases = resolve_aliases(config["aliases"], hostnames)
+        full_hostlist = resolve_hostlist(args.host_refs, hostnames, aliases)
         selected_hosts = restrict_hostlist(
             full_hostlist, args.start_at, args.stop_before)
     except HostlistError as e:
         print_error("{}", e)
         sys.exit(1)
 
-    returnValue(selected_hosts)
+    returnValue([hosts_by_name[name] for name in selected_hosts])
 
 
 @inlineCallbacks
@@ -165,7 +168,7 @@ def _main(reactor, *raw_args):
     # execute
     if args.list_hosts:
         for host in hosts:
-            print host
+            print host.name
     else:
         deployer = Deployer(config, event_bus, args.parallel, args.sleeptime)
 

--- a/rollingpin/transports/mock.py
+++ b/rollingpin/transports/mock.py
@@ -28,7 +28,9 @@ class MockTransportConnection(TransportConnection):
         command, args = command[0], command[1:]
         result = {}
 
-        if command == "build":
+        if command == "synchronize":
+            log.debug("MOCK: git fetch")
+        elif command == "build":
             log.debug("MOCK: build stuff")
             for arg in args:
                 result[arg] = "build-token"


### PR DESCRIPTION
This is the first phase of moving to hippo deploys. Instead of passing around a hostname as a string everywhere, we pass around host objects. These allow us to carry more info about the host. Then this allows us to use the IP address from the autoscaler inventory instead of relying on DNS. This removes the dependency on legacy DNS for deploys and should help get rollout in touch with boxes that are in the waitingdns state.

:eyeglasses: @dellis23 @ckwang8128 