### PR TITLE
[IO-352] Hippo Host inventory

### DIFF
--- a/rollingpin/hostsources/__init__.py
+++ b/rollingpin/hostsources/__init__.py
@@ -5,11 +5,11 @@ class HostSourceError(Exception):
     pass
 
 
-_Host = collections.namedtuple("_Host", "name address")
+_Host = collections.namedtuple("_Host", "id name address pool")
 class Host(_Host):
     @classmethod
     def from_hostname(cls, name):
-        return Host(name, name)
+        return Host(name, name, name, "")
 
 
 class HostSource(object):

--- a/rollingpin/hostsources/hippo.py
+++ b/rollingpin/hostsources/hippo.py
@@ -1,0 +1,91 @@
+import json
+import logging
+import posixpath
+
+import zookeeper
+from twisted.internet.defer import (
+    gatherResults,
+    inlineCallbacks,
+    returnValue,
+)
+from txzookeeper.client import ZookeeperClient
+
+from ..config import Option
+from ..hostsources import Host, HostSource, HostSourceError
+from ..utils import parallel_map
+
+
+class HippoHostSource(HostSource):
+    config_spec = {
+        "hostsource": {
+            "connection-string": Option(str),
+            "user": Option(str, default=None),
+            "password": Option(str, default=None),
+        },
+    }
+
+    def __init__(self, config):
+        # zoopy is really friggin' loud without this
+        zookeeper.set_debug_level(0)
+
+        connection_string = config["hostsource"]["connection-string"]
+        self.client = ZookeeperClient(connection_string, session_timeout=3000)
+        self.user = config["hostsource"]["user"]
+        self.password = config["hostsource"]["password"]
+
+    @inlineCallbacks
+    def _get_host_info(self, instance_id):
+        host_node_path = posixpath.join("/hosts", instance_id)
+        try:
+            host_json, znode = yield self.client.get(host_node_path)
+        except zookeeper.NoNodeException:
+            returnValue(None)
+
+        host_info = json.loads(host_json)
+        tags = {tag["Key"]: tag["Value"]
+                for tag in host_info["properties"]["tags"]}
+        try:
+            hostname = tags["Name"]
+        except KeyError:
+            try:
+                hostname = tags["HostClass"] + instance_id[1:]
+                logging.debug("falling back to hostclass for %r", hostname)
+            except KeyError:
+                hostname = instance_id
+                logging.debug("falling back to instance id for %r", hostname)
+
+        address = host_info["properties"]["private_ip"]
+        pool = tags.get("aws:autoscaling:groupName", "")
+
+        returnValue(Host(instance_id, hostname, address, pool))
+
+    @inlineCallbacks
+    def get_hosts(self):
+        try:
+            yield self.client.connect()
+
+            if self.user:
+                yield self.client.add_auth(
+                    "digest", "%s:%s" % (self.user, self.password))
+
+            instance_ids = yield self.client.get_children("/hosts")
+            hosts = yield parallel_map(instance_ids, self._get_host_info)
+            returnValue(filter(None, hosts))
+        except zookeeper.ZooKeeperException as e:
+            raise HostSourceError(e)
+
+    @inlineCallbacks
+    def should_be_alive(self, host):
+        instance_root = "/hosts/%s" % host.id
+
+        try:
+            yield self.client.get(instance_root)
+            returnValue(True)
+        except zookeeper.NoNodeException:
+            # ok, it's just a bad node
+            returnValue(False)
+        except zookeeper.ZooKeeperException as e:
+            # fail safe
+            logging.warning(
+                "hippo: failed to check liveliness for %r: %s", host.name, e)
+            returnValue(True)

--- a/rollingpin/hostsources/hippo.py
+++ b/rollingpin/hostsources/hippo.py
@@ -42,8 +42,7 @@ class HippoHostSource(HostSource):
             returnValue(None)
 
         host_info = json.loads(host_json)
-        tags = {tag["Key"]: tag["Value"]
-                for tag in host_info["properties"]["tags"]}
+        tags = host_info["properties"]["tags"]
         try:
             hostname = tags["Name"]
         except KeyError:

--- a/rollingpin/hostsources/mock.py
+++ b/rollingpin/hostsources/mock.py
@@ -17,7 +17,7 @@ class MockHostSource(HostSource):
         self.hosts = config["hostsource"]["hosts"].split()
 
     def get_hosts(self):
-        return succeed(Host(name, name + ".local") for name in self.hosts)
+        return succeed(Host(name, name, name + ".local", "") for name in self.hosts)
 
     def should_be_alive(self, host):
         return succeed(random.choice((True, True, True, False)))

--- a/rollingpin/main.py
+++ b/rollingpin/main.py
@@ -125,21 +125,18 @@ def _select_hosts(config, args):
         print_error("could not fetch host list: {}", e)
         sys.exit(1)
 
-    all_hosts = interleaved(all_hosts_unsorted, key=lambda h: h.pool)
-
-    hosts_by_name = {host.name: host for host in all_hosts}
-    hostnames = hosts_by_name.keys()
+    hosts = interleaved(all_hosts_unsorted, key=lambda h: h.pool)
 
     try:
-        aliases = resolve_aliases(config["aliases"], hostnames)
-        full_hostlist = resolve_hostlist(args.host_refs, hostnames, aliases)
+        aliases = resolve_aliases(config["aliases"], hosts)
+        full_hostlist = resolve_hostlist(args.host_refs, hosts, aliases)
         selected_hosts = restrict_hostlist(
             full_hostlist, args.start_at, args.stop_before)
     except HostlistError as e:
         print_error("{}", e)
         sys.exit(1)
 
-    returnValue([hosts_by_name[name] for name in selected_hosts])
+    returnValue(selected_hosts)
 
 
 @inlineCallbacks

--- a/rollingpin/main.py
+++ b/rollingpin/main.py
@@ -27,7 +27,7 @@ from .hostsources import HostSourceError
 from .graphite import enable_graphite_notifications
 from .log import log_to_file
 from .providers import get_provider, UnknownProviderError
-from .utils import random_word
+from .utils import random_word, interleaved
 
 
 CONFIG_SPEC = {
@@ -120,10 +120,12 @@ def _parse_args(config, raw_args):
 def _select_hosts(config, args):
     # get the list of hosts from the host source
     try:
-        all_hosts = yield config["hostsource"].get_hosts()
+        all_hosts_unsorted = yield config["hostsource"].get_hosts()
     except HostSourceError as e:
         print_error("could not fetch host list: {}", e)
         sys.exit(1)
+
+    all_hosts = interleaved(all_hosts_unsorted, key=lambda h: h.pool)
 
     hosts_by_name = {host.name: host for host in all_hosts}
     hostnames = hosts_by_name.keys()

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         "rollingpin.hostsource": [
             "mock = rollingpin.hostsources.mock:MockHostSource",
             "autoscaler = rollingpin.hostsources.autoscaler:AutoscalerHostSource",
+            "hippo = rollingpin.hostsources.hippo:HippoHostSource",
         ],
 
         "rollingpin.transport": [


### PR DESCRIPTION
This does some refactoring to commonize stuff that was previously in the autoscaler host source. Then we just add a simple hippo hostsource. This should be functionally pretty similar to the autoscaler host source, but not reliant on the old autoscaler stuff.

I'm not super clear on the right behaviour for the liveliness check; we basically just want to know "was this host terminated during my deploy?" so I think checking the existence of the node is a decent proxy for that.

I have tested this hostsource against production data: We need to do some cleaning up of hostnames / tags, particularly for the mothership fleets. On the other side, it found a host that was missing in autoscaler.
