### PR TITLE
Remove unneeded logging calls that cause extraneous handler

### DIFF
--- a/rollingpin/hostsources/hippo.py
+++ b/rollingpin/hostsources/hippo.py
@@ -48,10 +48,8 @@ class HippoHostSource(HostSource):
         except KeyError:
             try:
                 hostname = tags["HostClass"] + instance_id[1:]
-                logging.debug("falling back to hostclass for %r", hostname)
             except KeyError:
                 hostname = instance_id
-                logging.debug("falling back to instance id for %r", hostname)
 
         address = host_info["properties"]["private_ip"]
         pool = tags.get("aws:autoscaling:groupName", "")


### PR DESCRIPTION
These logging calls aren't terribly helpful outside of development but
since they're made so early on in the app startup, they're causing an
extra StreamHandler to get automatically created. This ends up making
every log statement later on in the app doubled; once through the
automatically made and defaultly styled handler, and once through our
colorized and fancy one. Removing the logging calls makes this safe.

:eyeglasses: @bsimpson63 @dellis23 