### PR TITLE
Add additional metadata about deploys to ES, Don't split docs on multiple components

### DIFF
--- a/rollingpin/elasticsearch.py
+++ b/rollingpin/elasticsearch.py
@@ -1,3 +1,5 @@
+"""Reports deploy metadata to elasticsearch"""
+import getpass
 import json
 import logging
 import time
@@ -33,48 +35,79 @@ class JSONBodyProducer(object):
 
 
 class ElasticSearchNotifier(object):
-    def __init__(self, config, components):
+    def __init__(self, config, components, hosts, command_line, word):
         self.logger = logging.getLogger(__name__)
         base_url = config["elasticsearch"]["endpoint"]
         index = config["elasticsearch"]["index"]
         index_type = config["elasticsearch"]["type"]
-        self.endpoint = "https://%s/%s/%s/_bulk" % (base_url, index, index_type)
+        self.hosts = hosts
+        self.command_line = command_line
+        self.deploy_name = word
+        self.endpoint = "https://%s/%s/%s" % (base_url, index, index_type)
         self.components = components
 
-    @staticmethod
-    def bulk_updates(components):
-        now = int(time.time())
-        actions = []
-        for service in components:
-            actions.append(json.dumps({'index': {}}))
-            actions.append(json.dumps({
-                'timestamp': now,
-                'service': service
-            }))
-        return actions
-
-    @staticmethod
-    def request_body(components):
-        """ Request body for bulk elastic search update
-        Newline delimited JSON blobs with a newline after the last item
+    def index_doc(self, doc):
+        """ Index a document in Elasticsearch
+        :param doc: dictionary with data to index in ES
+        :return: Deferred
         """
-        return "\n".join(ElasticSearchNotifier.bulk_updates(components)) + "\n"
-
-    @inlineCallbacks
-    def on_deploy_start(self):
         with swallow_exceptions("elasticsearch", self.logger):
             agent = Agent(reactor)
-            body = JSONBodyProducer(self.request_body(self.components))
-            yield agent.request(
+            body = JSONBodyProducer(json.dumps(doc))
+            return agent.request(
                 'POST',
                 self.endpoint,
                 Headers({'User-Agent': ['rollingpin']}),
-                body
+                body,
             )
 
+    def deploy_start_doc(self):
+        now = int(time.time())
+        return {
+            'id': self.deploy_name,
+            'timestamp': now,
+            'components': self.components,
+            'deployer': getpass.getuser(),
+            'command': self.command_line,
+            'hosts': self.hosts,
+            'host_count': len(self.hosts),
+            'event_type': 'deploy.begin',
+        }
 
-def enable_elastic_search_notifications(config, event_bus, components):
-    notifier = ElasticSearchNotifier(config, components)
+    def deploy_abort_doc(self, reason):
+        now = int(time.time())
+        return {
+            'id': self.deploy_name,
+            'timestamp': now,
+            'reason': reason,
+            'event_type': 'deploy.abort',
+        }
+
+    def deploy_end_doc(self):
+        now = int(time.time())
+        return {
+            'id': self.deploy_name,
+            'timestamp': now,
+            'event_type': 'deploy.end',
+        }
+
+    @inlineCallbacks
+    def on_deploy_start(self):
+        yield self.index_doc(self.deploy_start_doc())
+
+    @inlineCallbacks
+    def on_deploy_abort(self, reason):
+        yield self.index_doc(self.deploy_abort_doc(reason))
+
+    @inlineCallbacks
+    def on_deploy_end(self):
+        yield self.index_doc(self.deploy_end_doc())
+
+
+def enable_elastic_search_notifications(config, event_bus, components, hosts, command_line, word):
+    notifier = ElasticSearchNotifier(config, components, hosts, command_line, word)
     event_bus.register({
         "deploy.begin": notifier.on_deploy_start,
+        "deploy.abort": notifier.on_deploy_abort,
+        "deploy.end": notifier.on_deploy_end,
     })

--- a/rollingpin/main.py
+++ b/rollingpin/main.py
@@ -167,7 +167,7 @@ def _main(reactor, *raw_args):
         enable_graphite_notifications(config, event_bus, args.components)
 
     if config["elasticsearch"]["endpoint"]:
-        enable_elastic_search_notifications(config, event_bus, args.components)
+        enable_elastic_search_notifications(config, event_bus, args.components, hosts, args.original, word)
 
     if os.isatty(sys.stdout.fileno()):
         HeadfulFrontend(event_bus, hosts, args.verbose_logging, args.pause_after)

--- a/tests/elasticsearch.py
+++ b/tests/elasticsearch.py
@@ -1,58 +1,77 @@
+import json
 import unittest
 from mock import MagicMock, patch
-from twisted.web.http_headers import Headers
+
 from rollingpin.elasticsearch import ElasticSearchNotifier
 
 
+@patch('time.time', MagicMock(return_value=1))
 class TestElasticSearchNotifier(unittest.TestCase):
-
     def setUp(self):
         self.components = ["service-1", "service-2"]
-
-    @patch('time.time', MagicMock(return_value=1))
-    def test_bulk_updates(self):
-        bulk_updates = ElasticSearchNotifier.bulk_updates(self.components)
-        self.assertEquals([
-            '{"index": {}}',
-            '{"timestamp": 1, "service": "service-1"}',
-            '{"index": {}}',
-            '{"timestamp": 1, "service": "service-2"}',
-        ], bulk_updates)
-
-    def test_request_body(self):
-        bulk_updates = MagicMock(return_value=["1", "2", "3"])
-        patch_target = 'rollingpin.elasticsearch.ElasticSearchNotifier.bulk_updates'  # noqa
-        with patch(patch_target, bulk_updates):
-            body = ElasticSearchNotifier.request_body(self.components)
-            self.assertEquals(body, "1\n2\n3\n")
-
-    @patch('rollingpin.elasticsearch.reactor', MagicMock())
-    @patch('time.time', MagicMock(return_value=1))
-    def test_on_deploy_start(self):
-        components = ["service-1", "service-2"]
-        config = {
+        self.hosts = ["host1", "host2", "host3"]
+        self.command = "somerolloutcommand"
+        self.deploy_word = "fat-rabbit"
+        self.config = {
             "elasticsearch": {
                 "endpoint": "metric.com:123",
                 "index": "myindex",
                 "type": "mytype"
             }
         }
+        self.es_notifier_args = [self.config, self.components, self.hosts, self.command, self.deploy_word]
+        self.es_notifier = ElasticSearchNotifier(*self.es_notifier_args)
+
+    @patch('rollingpin.elasticsearch.reactor', MagicMock())
+    def test_index_doc(self):
         agent = MagicMock()
-        agent_module = MagicMock(return_value=agent)
-        with patch('rollingpin.elasticsearch.Agent', agent_module):
-            notifier = ElasticSearchNotifier(config, components)
-            notifier.on_deploy_start()
+        doc = {'hello': 'world'}
+        with patch('rollingpin.elasticsearch.Agent', MagicMock(return_value=agent)):
+            self.es_notifier.index_doc(doc)
+
         agent.request.assert_called()
         args = agent.request.call_args[0]
         self.assertEquals(len(args), 4)
-        method, endpoint, headers, body_producer = args
+        method, endpoint, headers, body = args
         self.assertEquals(method, 'POST')
-        self.assertEquals(endpoint, 'https://metric.com:123/myindex/mytype/_bulk')
+        self.assertEquals(endpoint, 'https://metric.com:123/myindex/mytype')
         header_list = [{key: value}
                        for key, value in headers.getAllRawHeaders()]
         self.assertEquals(header_list, [{'User-Agent': ['rollingpin']}])
-        expected_body = ('{"index": {}}\n'
-                         '{"timestamp": 1, "service": "service-1"}\n'
-                         '{"index": {}}\n'
-                         '{"timestamp": 1, "service": "service-2"}\n')
-        self.assertEquals(expected_body, body_producer.getBody())
+        self.assertEquals(body.getBody(), json.dumps(doc))
+
+    def test_deploy_start_doc(self):
+        deployer = "mr_cool_guy"
+        with patch('getpass.getuser', MagicMock(return_value=deployer)):
+            deploy_start_doc = self.es_notifier.deploy_start_doc()
+        expected_deploy_start_doc = {
+            'host_count': len(self.hosts),
+            'hosts': self.hosts,
+            'command': self.command,
+            'event_type': 'deploy.begin',
+            'components': self.components,
+            'deployer': deployer,
+            'timestamp': 1,
+            'id': self.deploy_word
+        }
+        self.assertEquals(deploy_start_doc, expected_deploy_start_doc)
+
+    def test_deploy_abort_doc(self):
+        reason = "farrabbitssss"
+        deploy_abort_doc = self.es_notifier.deploy_abort_doc(reason)
+        expected_deploy_abort_doc = {
+            'timestamp': 1,
+            'reason': 'farrabbitssss',
+            'id': self.deploy_word,
+            'event_type': 'deploy.abort'
+        }
+        self.assertEquals(deploy_abort_doc, expected_deploy_abort_doc)
+
+    def test_deploy_end_doc(self):
+        deploy_end_doc = self.es_notifier.deploy_end_doc()
+        expected_deploy_end_doc = {
+            'timestamp': 1,
+            'id': self.deploy_word,
+            'event_type': 'deploy.end'
+        }
+        self.assertEquals(deploy_end_doc, expected_deploy_end_doc)


### PR DESCRIPTION
Now that we have metadata being dispatched to ES, lets start sending more deploy metadata to elasticsearch