### PR TITLE
ES timestamp in milliseconds, send more info on abort, end events

### DIFF
--- a/rollingpin/elasticsearch.py
+++ b/rollingpin/elasticsearch.py
@@ -63,10 +63,10 @@ class ElasticSearchNotifier(object):
             )
 
     def deploy_start_doc(self):
-        now = int(time.time())
+        timestamp_in_milliseconds = int(time.time()) * 1000
         return {
             'id': self.deploy_name,
-            'timestamp': now,
+            'timestamp': timestamp_in_milliseconds,
             'components': self.components,
             'deployer': getpass.getuser(),
             'command': self.command_line,
@@ -76,19 +76,21 @@ class ElasticSearchNotifier(object):
         }
 
     def deploy_abort_doc(self, reason):
-        now = int(time.time())
+        timestamp_in_milliseconds = int(time.time()) * 1000
         return {
             'id': self.deploy_name,
-            'timestamp': now,
+            'timestamp': timestamp_in_milliseconds,
             'reason': reason,
+            'components': self.components,
             'event_type': 'deploy.abort',
         }
 
     def deploy_end_doc(self):
-        now = int(time.time())
+        timestamp_in_milliseconds = int(time.time()) * 1000
         return {
             'id': self.deploy_name,
-            'timestamp': now,
+            'timestamp': timestamp_in_milliseconds,
+            'components': self.components,
             'event_type': 'deploy.end',
         }
 

--- a/tests/elasticsearch.py
+++ b/tests/elasticsearch.py
@@ -51,7 +51,7 @@ class TestElasticSearchNotifier(unittest.TestCase):
             'event_type': 'deploy.begin',
             'components': self.components,
             'deployer': deployer,
-            'timestamp': 1,
+            'timestamp': 1000,
             'id': self.deploy_word
         }
         self.assertEquals(deploy_start_doc, expected_deploy_start_doc)
@@ -60,8 +60,9 @@ class TestElasticSearchNotifier(unittest.TestCase):
         reason = "farrabbitssss"
         deploy_abort_doc = self.es_notifier.deploy_abort_doc(reason)
         expected_deploy_abort_doc = {
-            'timestamp': 1,
+            'timestamp': 1000,
             'reason': 'farrabbitssss',
+            'components': self.components,
             'id': self.deploy_word,
             'event_type': 'deploy.abort'
         }
@@ -70,7 +71,8 @@ class TestElasticSearchNotifier(unittest.TestCase):
     def test_deploy_end_doc(self):
         deploy_end_doc = self.es_notifier.deploy_end_doc()
         expected_deploy_end_doc = {
-            'timestamp': 1,
+            'timestamp': 1000,
+            'components': self.components,
             'id': self.deploy_word,
             'event_type': 'deploy.end'
         }


### PR DESCRIPTION
Our current version of Grafana does not support elasticsearch
timetamps to be in seconds. Need to convert them into milliseconds
before sending them off. Also correlate deploy end events with the service
so we can filter them easily in Grafana