### PR TITLE
Don't append local to mock addresses.

### DIFF
--- a/rollingpin/hostsources/mock.py
+++ b/rollingpin/hostsources/mock.py
@@ -17,7 +17,7 @@ class MockHostSource(HostSource):
         self.hosts = config["hostsource"]["hosts"].split()
 
     def get_hosts(self):
-        return succeed(Host(name, name, name + ".local", "")
+        return succeed(Host(name, name, name, "")
                        for name in self.hosts)
 
     def should_be_alive(self, host):


### PR DESCRIPTION
👓 @spladug @foklepoint 

I don't know if this is the actual solution we want, but right now the gangplank server can't deploy without this commit hotpatched in, and I didn't want to just leave it around.  Alternatively, should we just have a host source that is for a static list of hosts?  Or is there enough of an overlap with the mock host source that it'd be unnecessary?