### PR TITLE
Lazily resolve host aliases to avoid blocking on unrelated projects

### DIFF
--- a/rollingpin/hostlist.py
+++ b/rollingpin/hostlist.py
@@ -44,20 +44,16 @@ def parse_aliases(config_parser):
     return aliases
 
 
-def resolve_aliases(unresolved_aliases, all_hosts):
-    aliases = {}
-    for alias, globs in unresolved_aliases.iteritems():
-        hosts = []
+def resolve_alias(all_hosts, globs):
+    hosts = []
 
-        for glob in globs:
-            globbed = [host for host in all_hosts
-                       if fnmatch.fnmatch(host.name, glob)]
-            if not globbed:
-                raise UnresolvableAliasError(glob)
-            hosts.extend(globbed)
-
-        aliases[alias] = hosts
-    return aliases
+    for glob in globs:
+        globbed = [host for host in all_hosts
+                   if fnmatch.fnmatch(host.name, glob)]
+        if not globbed:
+            raise UnresolvableAliasError(glob)
+        hosts.extend(globbed)
+    return hosts
 
 
 def resolve_hostlist(host_refs, all_hosts, aliases):
@@ -68,7 +64,8 @@ def resolve_hostlist(host_refs, all_hosts, aliases):
         ref = unresolved_refs.popleft()
 
         if ref in aliases:
-            resolved_hosts.extend(aliases[ref])
+            hosts = resolve_alias(all_hosts, aliases[ref])
+            resolved_hosts.extend(hosts)
         else:
             matching_hosts = [host for host in all_hosts if host.name == ref]
 

--- a/rollingpin/hostlist.py
+++ b/rollingpin/hostlist.py
@@ -1,4 +1,3 @@
-import collections
 import fnmatch
 import itertools
 

--- a/rollingpin/hostlist.py
+++ b/rollingpin/hostlist.py
@@ -57,12 +57,9 @@ def resolve_alias(all_hosts, globs):
 
 
 def resolve_hostlist(host_refs, all_hosts, aliases):
-    unresolved_refs = collections.deque(host_refs)
     resolved_hosts = []
 
-    while unresolved_refs:
-        ref = unresolved_refs.popleft()
-
+    for ref in host_refs:
         if ref in aliases:
             hosts = resolve_alias(all_hosts, aliases[ref])
             resolved_hosts.extend(hosts)

--- a/rollingpin/main.py
+++ b/rollingpin/main.py
@@ -137,8 +137,8 @@ def _select_hosts(config, args):
     hosts = interleaved(all_hosts_unsorted, key=lambda h: h.pool)
 
     try:
-        aliases = resolve_aliases(config["aliases"], hosts)
-        full_hostlist = resolve_hostlist(args.host_refs, hosts, aliases)
+        full_hostlist = resolve_hostlist(
+            args.host_refs, hosts, config["aliases"])
         selected_hosts = restrict_hostlist(
             full_hostlist, args.start_at, args.stop_before)
     except HostlistError as e:

--- a/tests/hostlist.py
+++ b/tests/hostlist.py
@@ -79,6 +79,14 @@ class TestHostListResolution(unittest.TestCase):
         with self.assertRaises(UnresolvableHostRefError):
             resolve_hostlist(["bad"], [MockHost("a"), MockHost("b")], {})
 
+    def test_bad_unrelated_alias(self):
+        a, b, c = MockHost("a"), MockHost("b"), MockHost("c")
+        hostlist = resolve_hostlist(["good_alias"], [a, b, c], {
+            "good_alias": "a",
+            "bad_alias": "d",
+        })
+        self.assertEqual(hostlist, [a])
+
 
 class TestHostListRestriction(unittest.TestCase):
     def setUp(self):

--- a/tests/hostlist.py
+++ b/tests/hostlist.py
@@ -4,7 +4,7 @@ import unittest
 from rollingpin.hostlist import (
     HostSelectionError,
     parse_aliases,
-    resolve_aliases,
+    resolve_alias,
     resolve_hostlist,
     restrict_hostlist,
     UnresolvableAliasError,
@@ -42,22 +42,22 @@ class TestAliasParsing(unittest.TestCase):
 
 class TestAliasResolution(unittest.TestCase):
     def test_resolve_nothing(self):
-        aliases = resolve_aliases({}, [])
-        self.assertEqual(aliases, {})
+        aliases = resolve_alias([], [])
+        self.assertEqual(aliases, [])
 
     def test_resolve_direct_names(self):
         b = MockHost("b")
-        aliases = resolve_aliases({"a": ["b"]}, [b])
-        self.assertEqual(aliases, {"a": [b]})
+        hosts = resolve_alias([b], ["b"])
+        self.assertEqual(hosts, [b])
 
     def test_unsatisfied_glob(self):
         with self.assertRaises(UnresolvableAliasError):
-            resolve_aliases({"a": ["b"]}, [])
+            resolve_alias([], ["a"])
 
     def test_glob(self):
         a_1, a_2, b_1 = MockHost("a-1"), MockHost("a-2"), MockHost("b-1")
-        aliases = resolve_aliases({"a": ["a-*"]}, [a_1, a_2, b_1])
-        self.assertEqual(aliases, {"a": [a_1, a_2]})
+        aliases = resolve_alias([a_1, a_2, b_1], ["a-*"])
+        self.assertEqual(aliases, [a_1, a_2])
 
 
 class TestHostListResolution(unittest.TestCase):
@@ -72,7 +72,7 @@ class TestHostListResolution(unittest.TestCase):
 
     def test_aliases(self):
         a, b, c = MockHost("a"), MockHost("b"), MockHost("c")
-        hostlist = resolve_hostlist(["alias"], [a, b, c], {"alias": [a, b]})
+        hostlist = resolve_hostlist(["alias"], [a, b, c], {"alias": ["a", "b"]})
         self.assertEqual(hostlist, [a, b])
 
     def test_unknown_ref(self):


### PR DESCRIPTION
When a service is being spun up or down we'll have aliases in the
rollingpin config that don't resolve to any live servers. Previously,
this would cause rollout to complain about the alias being unresolvable
since it was trying to prevent silent failure. That is pretty
frustrating for people trying to deploy to unrelated projects. This
makes it so that aliases are only resolved when specified on the command
line and so we'll only complain at you if we're unable to resolve hosts
for something you specifically requested.