### PR TITLE
Add Component Report

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,37 +95,3 @@ docker build . -t rollingpin:test && docker run --rm rollingpin:test
 
 [1]: http://i.imgur.com/66Nr9Wo.jpg
 [2]: https://github.com/spladug/harold
-
-Deploy Commands
------
-While any arbitrary command can be supported by your deploy script,
-there are a few that rollingpin has special support for.
-
-### component_report ###
-
-The ``component_report`` command collects information about the SHA of each
-running process across all target hosts.  It can be used to identify hanging
-processes.  A summary report will be a printed to stdout, in the format:
-
-    *** component report
-    COMPONENT      SHA     COUNT
-    foo         012345      1
-    bar         abcdef      1
-
-To support this functionality, the ``component_report`` in your deploy script
-should return a result containing all running SHAs of all components on the
-host, in the format:
-
-    {
-        'components': {
-            'foo': '012345',
-            'bar': 'abcdef',
-        }
-    }
-
-The ``component_report`` in your deploy script should also print more detailed
-information to **stderr** to allow an operator to dig in further if a problem is
-found.  The suggested format of this output:
-
-    component: app-123 foo@012345
-    component: app-123 bar@abcdef

--- a/README.md
+++ b/README.md
@@ -103,12 +103,12 @@ there are a few that rollingpin has special support for.
 
 ### build ###
 
-If `build-host` is present in the root directory of your project, rollingpin
+If ``build-host`` is present in the root directory of your project, rollingpin
 will attempt to connect to that host and run the following:
 
     deploy-script build foo@01234567 bar@abcdef
 
-Where each argument passed is the name of a deploy target and the sha that
+Where each argument passed is the name of a deploy target and the SHA that
 will be deployed.  The build command in your deploy script should take these
 arguments, do whatever building is necessary, and return a result in the
 format:
@@ -117,3 +117,32 @@ format:
         'foo@012345': '012345',
         'bar@abcdef': 'abcdef',
     }
+
+### component_report ###
+
+The ``component_report`` command collects information about the SHA of each
+running process across all target hosts.  It can be used to identify hanging
+processes.  A summary report will be a printed to stdout, in the format:
+
+    *** component report
+    COMPONENT      SHA     COUNT
+    foo         012345      1
+    bar         abcdef      1
+
+To support this functionality, the ``component_report`` in your deploy script
+should return a result containing all running SHAs of all components on the
+host, in the format:
+
+    {
+        'components': {
+            'foo': '012345',
+            'bar': 'abcdef',
+        }
+    }
+
+The ``component_report`` in your deploy script should also print more detailed
+information to **stderr** to allow an operator to dig in further if a problem is
+found.  The suggested format of this output:
+
+    component: app-123 foo@012345
+    component: app-123 bar@abcdef

--- a/README.md
+++ b/README.md
@@ -95,3 +95,25 @@ docker build . -t rollingpin:test && docker run --rm rollingpin:test
 
 [1]: http://i.imgur.com/66Nr9Wo.jpg
 [2]: https://github.com/spladug/harold
+
+Deploy Commands
+-----
+While any arbitrary command can be supported by your deploy script,
+there are a few that rollingpin has special support for.
+
+### build ###
+
+If `build-host` is present in the root directory of your project, rollingpin
+will attempt to connect to that host and run the following:
+
+    deploy-script build foo@01234567 bar@abcdef
+
+Where each argument passed is the name of a deploy target and the sha that
+will be deployed.  The build command in your deploy script should take these
+arguments, do whatever building is necessary, and return a result in the
+format:
+
+    {
+        'foo@012345': '012345',
+        'bar@abcdef': 'abcdef',
+    }

--- a/README.md
+++ b/README.md
@@ -101,23 +101,6 @@ Deploy Commands
 While any arbitrary command can be supported by your deploy script,
 there are a few that rollingpin has special support for.
 
-### build ###
-
-If ``build-host`` is present in the root directory of your project, rollingpin
-will attempt to connect to that host and run the following:
-
-    deploy-script build foo@01234567 bar@abcdef
-
-Where each argument passed is the name of a deploy target and the SHA that
-will be deployed.  The build command in your deploy script should take these
-arguments, do whatever building is necessary, and return a result in the
-format:
-
-    {
-        'foo@012345': '012345',
-        'bar@abcdef': 'abcdef',
-    }
-
 ### component_report ###
 
 The ``component_report`` command collects information about the SHA of each

--- a/example-deploy.py
+++ b/example-deploy.py
@@ -74,9 +74,6 @@ def build(*components_with_tokens):
 
     This command is required if you want to run "-d" commands in rollingpin.
 
-    If ``build-host`` is present in the root directory of your project, rollingpin
-    will run the build command on the host specified in the file.
-
     """
 
     res = {}

--- a/example-deploy.py
+++ b/example-deploy.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 import json
 import os
+import socket
 import subprocess
 import sys
 
@@ -102,6 +103,48 @@ def deploy(*components_with_tokens):
         assert sep == "@"
 
         # TODO: put your deploy logic here!
+
+
+def component_report():
+    """Collect information about the SHA of each running process.
+
+    This can be used to identify hanging processes.  A summary report will be
+    a printed to stdout, in the format:
+
+        *** component report
+        COMPONENT      SHA     COUNT
+        foo         012345      1
+        bar         abcdef      1
+
+    To support this functionality, the `component_report` command should
+    return a result containing all running SHAs of all components on the
+    host, in the format:
+
+        {
+            'components': {
+                'foo': '012345',
+                'bar': 'abcdef',
+            }
+        }
+
+    The `component_report` command should also print more detailed
+    information to stderr to allow an operator to dig in further if a
+    problem is found.  The suggested format of this output:
+
+        component: app-123 foo@012345
+        component: app-123 bar@abcdef
+
+    """
+    components = {
+        'components': {
+            'foo': '012345',
+        },
+    }
+    hostname = socket.gethostname()
+    for component, commit_hash in components['components'].iteritems():
+        print("component: %s %s %s" % (hostname, component, commit_hash),
+              file=sys.stderr)
+    return components
 
 
 def restart(service):

--- a/example-deploy.py
+++ b/example-deploy.py
@@ -105,7 +105,7 @@ def deploy(*components_with_tokens):
         # TODO: put your deploy logic here!
 
 
-def component_report():
+def components():
     """Collect information about the SHA of each running process.
 
     This can be used to identify hanging processes.  A summary report will be
@@ -116,7 +116,7 @@ def component_report():
         foo         012345      1
         bar         abcdef      1
 
-    To support this functionality, the `component_report` command should
+    To support this functionality, the `components` command should
     return a result containing all running SHAs of all components on the
     host, in the format:
 
@@ -127,7 +127,7 @@ def component_report():
             }
         }
 
-    The `component_report` command should also print more detailed
+    The `components` command should also print more detailed
     information to stderr to allow an operator to dig in further if a
     problem is found.  The suggested format of this output:
 
@@ -222,6 +222,7 @@ if __name__ == "__main__":
     main({
         "synchronize": synchronize,
         "build": build,
+        "components": components,
         "deploy": deploy,
         "restart": restart,
         "custom": custom,

--- a/example-deploy.py
+++ b/example-deploy.py
@@ -57,13 +57,24 @@ def synchronize(*components):
 def build(*components_with_tokens):
     """Build a component in preparation for deploy.
 
+    :param components_with_tokens: a list of deploy targets and SHAs to be
+        deployed, each in the format "foo@12345".
+
     This will be called once on each build host with a list of all components
     to build.  The script should prepare the components for deploy in whatever
     way is necessary (build a .deb package, fetch down from an SCM system,
     etc.) and return a mapping of components to tokens that identify the
-    relevant build artifacts.
+    relevant build artifacts, in the format:
+
+        {
+            'foo@012345': '012345',
+            'bar@abcdef': 'abcdef',
+        }
 
     This command is required if you want to run "-d" commands in rollingpin.
+
+    If ``build-host`` is present in the root directory of your project, rollingpin
+    will run the build command on the host specified in the file.
 
     """
 

--- a/rollingpin/deploy.py
+++ b/rollingpin/deploy.py
@@ -170,7 +170,8 @@ class Deployer(object):
                             component, at, sync_token = ref.partition("@")
                             assert at == "@"
                             try:
-                                deploy_ref = component + "@" + build_result.result[ref]
+                                deploy_ref = (component + "@" +
+                                              build_result.result[ref])
                             except KeyError:
                                 raise ComponentNotBuiltError(component)
                             deploy_command.append(deploy_ref)

--- a/rollingpin/deploy.py
+++ b/rollingpin/deploy.py
@@ -223,19 +223,11 @@ class Deployer(object):
                         # disk?
                         continue
 
-                # TODO: Where should this go?  I'm thinking the information
-                # should be provided to the frontend.
-                #
-                # TODO: Make this smarter.  It should only show anomolous
-                # stuff.  Or maybe color that stuff differently.  But that
-                # should be in frontends.
-                print "----------------"
-                print "component report"
-                print "----------------"
-                print "COMPONENT\tSHA\tCOUNT"
-                for component in report.keys():
-                    for sha, count in report[component].iteritems():
-                        print "%s\t%s\t%s" % (component, sha, count)
+                # TODO: Is there a better way to do this without creating a new
+                # event?  I think it could be passed along with the
+                # "deploy.end" event, but I need a way to get the report back
+                # from the DeferredList callback.
+                self.event_bus.trigger("component_report", report=report)
 
             # Commands are a list of lists.  Each sublist contains the command
             # and any arguments passed to the command.  We just need to figure

--- a/rollingpin/frontends.py
+++ b/rollingpin/frontends.py
@@ -70,8 +70,16 @@ def generate_component_report(host_results):
         for result in results.get('results', []):
             if result.command[0] != 'components':
                 continue
-            for component, sha in result.result['components'].iteritems():
-                report[component][sha] += 1
+            # Example result.result['components']:
+            #
+            #     {
+            #         'foo': {
+            #             'abcdef': 2,
+            #         },
+            #     }
+            for component, sha_counts in result.result['components'].iteritems():
+                for sha, count in sha_counts.iteritems():
+                    report[component][sha] += count
     return report
 
 

--- a/rollingpin/frontends.py
+++ b/rollingpin/frontends.py
@@ -85,7 +85,7 @@ class HeadlessFrontend(object):
         root = logging.getLogger()
         root.addHandler(self.log_handler)
 
-        self.host_results = dict.fromkeys(hosts, {})
+        self.host_results = {k: {} for k in hosts}
         self.start_time = None
 
         event_bus.register({

--- a/rollingpin/frontends.py
+++ b/rollingpin/frontends.py
@@ -89,6 +89,7 @@ class HeadlessFrontend(object):
         self.start_time = None
 
         event_bus.register({
+            "component_report": self.on_component_report,
             "deploy.begin": self.on_deploy_begin,
             "deploy.end": self.on_deploy_end,
             "deploy.abort": self.on_deploy_abort,
@@ -101,6 +102,15 @@ class HeadlessFrontend(object):
 
     def disable_verbose_logging(self):
         self.log_handler.setLevel(logging.INFO)
+
+    def on_component_report(self, report):
+        # TODO: Make this smarter.  It should only show anomolous
+        # stuff.  Or maybe color that stuff differently.
+        print colorize("*** component report", Color.GREEN)
+        print "COMPONENT\tSHA\tCOUNT"
+        for component in report.keys():
+            for sha, count in report[component].iteritems():
+                print "%s\t%s\t%s" % (component, sha, count)
 
     def on_deploy_begin(self):
         self.start_time = time.time()

--- a/rollingpin/frontends.py
+++ b/rollingpin/frontends.py
@@ -172,7 +172,7 @@ class HeadlessFrontend(object):
             if 'results' not in results:
                 continue
             for command, output in results['results']:
-                if command[0] != 'component_report':
+                if command[0] != 'components':
                     continue
                 for component, sha in output['components'].iteritems():
                     report[component][sha] += 1

--- a/rollingpin/frontends.py
+++ b/rollingpin/frontends.py
@@ -163,10 +163,10 @@ class HeadlessFrontend(object):
 
         report = collections.defaultdict(collections.Counter)
         for host, results in self.host_results.iteritems():
-            for command, output in results.get('results', []):
-                if command[0] != 'components':
+            for result in results.get('results', []):
+                if result.command[0] != 'components':
                     continue
-                for component, sha in output['components'].iteritems():
+                for component, sha in result.result['components'].iteritems():
                     report[component][sha] += 1
         if report:
             print colorize("*** component report", Color.BOLD(Color.GREEN))

--- a/rollingpin/frontends.py
+++ b/rollingpin/frontends.py
@@ -169,11 +169,16 @@ class HeadlessFrontend(object):
                 for component, sha in result.result['components'].iteritems():
                     report[component][sha] += 1
         if report:
+            # Pad the columns to reasonable max widths so the tabs will line up
+            # and be readable.  For SHAs, we expect 40 characters.  For
+            # components and counts, we choose some reasonably large lengths
+            # that we may need to adjust later.
+            fmt_string = "%20s\t%40s\t%10s"
             print colorize("*** component report", Color.BOLD(Color.GREEN))
-            print "COMPONENT\tSHA\tCOUNT"
+            print fmt_string % ("COMPONENT", "SHA", "COUNT")
             for component in report.keys():
                 for sha, count in report[component].iteritems():
-                    print "%s\t%s\t%s" % (component, sha, count)
+                    print fmt_string % (component, sha, count)
 
 
 class StdioListener(Protocol):

--- a/rollingpin/frontends.py
+++ b/rollingpin/frontends.py
@@ -161,7 +161,7 @@ class HeadlessFrontend(object):
         elapsed = time.time() - self.start_time
         print "*** elapsed time: %d seconds" % elapsed
 
-        report = collections.defaultdict(lambda: collections.Counter())
+        report = collections.defaultdict(collections.Counter)
         for host, results in self.host_results.iteritems():
             # Messed up hosts won't have results
             if 'results' not in results:

--- a/rollingpin/frontends.py
+++ b/rollingpin/frontends.py
@@ -161,11 +161,6 @@ class HeadlessFrontend(object):
         elapsed = time.time() - self.start_time
         print "*** elapsed time: %d seconds" % elapsed
 
-        # TODO: Make this smarter.  It should only show anomolous
-        # stuff.  Or maybe color that stuff differently.
-        #
-        # TODO: Check if component report was even requested before going
-        # through them all?
         report = collections.defaultdict(lambda: collections.Counter())
         for host, results in self.host_results.iteritems():
             # Messed up hosts won't have results

--- a/rollingpin/frontends.py
+++ b/rollingpin/frontends.py
@@ -163,10 +163,7 @@ class HeadlessFrontend(object):
 
         report = collections.defaultdict(collections.Counter)
         for host, results in self.host_results.iteritems():
-            # Messed up hosts won't have results
-            if 'results' not in results:
-                continue
-            for command, output in results['results']:
+            for command, output in results.get('results', []):
                 if command[0] != 'components':
                     continue
                 for component, sha in output['components'].iteritems():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[pep8]
+max-line-length = 100

--- a/tests/frontends.py
+++ b/tests/frontends.py
@@ -1,0 +1,76 @@
+import unittest
+
+from rollingpin.deploy import DeployResult
+from rollingpin.frontends import generate_component_report
+from rollingpin.hostsources import Host
+
+
+class TestFrontends(unittest.TestCase):
+
+    def test_coverage_report_generation(self):
+
+        # Setup
+        host = Host.from_hostname('test')
+        results = [
+            DeployResult(
+                command=['components'],
+                result={'components': {'foo': 'abcdef'}},
+            ),
+        ]
+        host_results = {host: {'status': "success", 'results': results}}
+
+        # Generate Report
+        report = generate_component_report(host_results)
+
+        # Verify
+        expected_report = {
+            'foo': {
+                'abcdef': 1,
+            },
+        }
+        self.assertEqual(report, expected_report)
+
+    def test_coverage_report_skips_other_commands(self):
+
+        # Setup
+        host = Host.from_hostname('test')
+        results = [
+            DeployResult(
+                command=['deploy', 'foo'],
+                result={},
+            ),
+            DeployResult(
+                command=['components'],
+                result={'components': {'foo': 'abcdef'}},
+            ),
+        ]
+        host_results = {host: {'status': "success", 'results': results}}
+
+        # Generate Report
+        report = generate_component_report(host_results)
+
+        # Verify
+        expected_report = {
+            'foo': {
+                'abcdef': 1,
+            },
+        }
+        self.assertEqual(report, expected_report)
+
+    def test_coverage_report_doesnt_break_when_no_coverage_report_requested(self):  # noqa
+
+        # Setup
+        host = Host.from_hostname('test')
+        results = [
+            DeployResult(
+                command=['deploy', 'foo'],
+                result={},
+            ),
+        ]
+        host_results = {host: {'status': "success", 'results': results}}
+
+        # Generate Report
+        report = generate_component_report(host_results)
+
+        # Verify
+        self.assertEqual(report, {})

--- a/tests/frontends.py
+++ b/tests/frontends.py
@@ -14,7 +14,7 @@ class TestFrontends(unittest.TestCase):
         results = [
             DeployResult(
                 command=['components'],
-                result={'components': {'foo': 'abcdef'}},
+                result={'components': {'foo': {'abcdef': 1}}},
             ),
         ]
         host_results = {host: {'status': "success", 'results': results}}
@@ -41,7 +41,7 @@ class TestFrontends(unittest.TestCase):
             ),
             DeployResult(
                 command=['components'],
-                result={'components': {'foo': 'abcdef'}},
+                result={'components': {'foo': {'abcdef': 1}}},
             ),
         ]
         host_results = {host: {'status': "success", 'results': results}}
@@ -74,3 +74,24 @@ class TestFrontends(unittest.TestCase):
 
         # Verify
         self.assertEqual(report, {})
+
+    def test_coverage_report_aggregates_multiple_hosts(self):
+
+        # Setup
+        results = [
+            DeployResult(
+                command=['components'],
+                result={'components': {'foo': {'abcdef': 1}}},
+            ),
+        ]
+        host_results = {
+            Host.from_hostname('test'): {'status': "success", 'results': results},
+            Host.from_hostname('test-2'): {'status': "success", 'results': results},
+        }
+
+        # Generate Report
+        report = generate_component_report(host_results)
+
+        # Verify
+        expected_report = {'foo': {'abcdef': 2}}
+        self.assertEqual(report, expected_report)


### PR DESCRIPTION
👓  @spladug @foklepoint 

Right now, the component report must be explicitly passed by the operator.  I think this makes things a lot cleaner so we don't have to inject the command in and gracefully handle when the deploy script doesn't support component reports.  My thinking is that we can look at making this happen every time later on if we find it useful.  This also obviates the need to be "smart" about the short format (i.e. don't show output if it looks like only one SHA is running per component), since the operator will have explicitly requested a report.  We can still do the smart thing if we make it required, but I want to makes sure it's clear when the component report is failing versus everything being okay (since both would seemingly result in no output under the smart case).

I wasn't sure when I began how to best structure this, since twisted isn't my strong suit, so I put the restructurings into various commits so they can be reverted / changed easily.  I'm open to ideas here, or if I'm doing something in a convoluted way, please let me know.

Also open to ideas on how to show the output.  Right now it's just a header row with each column separated by tabs.  I've included an example in the documentation.