### PR TITLE
Fix percent rollout edge cases

### DIFF
--- a/rollingpin/frontends.py
+++ b/rollingpin/frontends.py
@@ -133,7 +133,7 @@ class HeadlessFrontend(object):
         return sum(1 for v in self.host_results.itervalues() if v)
 
     def percent_complete(self):
-        return (self.count_completed_hosts() / self.count_hosts()) * 100
+        return int((self.count_completed_hosts() / self.count_hosts()) * 100)
 
     def on_host_end(self, host, results):
         if host in self.host_results:

--- a/rollingpin/frontends.py
+++ b/rollingpin/frontends.py
@@ -310,7 +310,10 @@ class HeadfulFrontend(HeadlessFrontend):
                 completed_hosts = self.count_completed_hosts()
                 desired_host_index = int(
                     (desired_percent / 100) * self.count_hosts())
-                self.pause_after = desired_host_index - completed_hosts
+
+                # since pause_after=0 means "don't pause", we want to make sure
+                # that rounding never accidentally puts us at zero
+                self.pause_after = max(desired_host_index - completed_hosts, 1)
                 break
 
         self.enqueued_hosts = 0


### PR DESCRIPTION
This fixes #10 and a case we saw with desktop2x (which has exactly 14 servers) where deploying to 10% would unleash the deploy but deploying to e.g. 15% would not.