### PR TITLE
Profile support for rollingpin

### DIFF
--- a/example_profile.ini
+++ b/example_profile.ini
@@ -1,19 +1,22 @@
-; this is an example profile configuration for rolling pin
+; this is an example profile configuration for rollingpin
 ; technically any value in the example.ini file can be used here
 ; but it is mostly for overriding and defaulting more execution values
+;
+; Note: should be located in /etc/rollingpin.d/ with the basename being the profile
+; this is for
 
 [deploy]
 ; this sets a default set of hosts to apply to (default for the '-h' argument)
-hosts = apps
+default-hosts = apps
 
 ; this sets a default set of components to deploy (default for the '-c' argument)
-components = rollingpin
+default-components = rollingpin
 
 ; this sets the default set of hosts to restart (default for the '-r' arguments)
-restarts = all
+default-restart = all
 
 [harold]
 ; per profile override of the '[harold]' section in the primary config (see the
 ; configuration there)
-base-url =
+base-url = http://example.com/
 secret =

--- a/example_profile.ini
+++ b/example_profile.ini
@@ -1,0 +1,19 @@
+; this is an example profile configuration for rolling pin
+; technically any value in the example.ini file can be used here
+; but it is mostly for overriding and defaulting more execution values
+
+[deploy]
+; this sets a default set of hosts to apply to (default for the '-h' argument)
+hosts = apps
+
+; this sets a default set of components to deploy (default for the '-c' argument)
+components = rollingpin
+
+; this sets the default set of hosts to restart (default for the '-r' arguments)
+restarts = all
+
+[harold]
+; per profile override of the '[harold]' section in the primary config (see the
+; configuration there)
+base-url =
+secret =

--- a/rollingpin/args.py
+++ b/rollingpin/args.py
@@ -278,6 +278,37 @@ def construct_canonical_commandline(config, args):
     return " ".join(arg_list)
 
 
+def build_action_summary(config, args):
+    expanded_command = os.path.basename(sys.argv[0]) + " " \
+            + construct_canonical_commandline(config, args)
+
+    summary_points = []
+
+    for component in args.components:
+        summary_points.append("Deploy the `{}` component.".format(component))
+
+    for command in args.commands:
+        if command[0] == "restart":
+            summary_points.append(
+                "Restart `{}` applications.".format(command[1]))
+        else:
+            summary_points.append("Run the `{}` command.".format(" ".join(command)))
+
+    summary_details = []
+
+    for host in args.host_refs:
+        summary_details.append("on `{}` hosts".format(host))
+
+    summary_details.append("{} at a time".format(args.parallel))
+    if args.timeout is not None:
+        summary_details.append(
+            "timing out if a host takes more than {} seconds".format(args.timeout))
+
+    return "\n".join([expanded_command, "", "This will:", ""] +
+                     ["* {}".format(p) for p in summary_points] +
+                     ["", ', '.join(summary_details), ""])
+
+
 def _get_available_profiles(profile_dir):
     profiles = []
     for f in os.listdir(profile_dir):

--- a/rollingpin/args.py
+++ b/rollingpin/args.py
@@ -236,6 +236,9 @@ def parse_args(config, raw_args=None, profile=None):
     for target in args.restart:
         args.commands.append(["restart", target])
 
+    if args.components == ["none"]:
+        args.components = []
+
     return args
 
 

--- a/rollingpin/args.py
+++ b/rollingpin/args.py
@@ -192,16 +192,16 @@ def _add_deploy_arguments(config, parser):
     )
 
     default_restart = config["deploy"].get("default-restart", [])
-    if default_restart:
-        default_restart = [["restart", default_restart]]
+    if not isinstance(default_restart, list):
+        default_restart = [default_restart]
 
     deploy_group.add_argument(
         "-r",
-        action=RestartCommand,
+        action="append",
         default=default_restart,
         help="whom to restart",
         metavar="TARGET",
-        dest="commands",
+        dest="restart",
     )
 
     deploy_group.add_argument(

--- a/rollingpin/args.py
+++ b/rollingpin/args.py
@@ -7,17 +7,16 @@ PAUSEAFTER_DEFAULT = 1
 
 
 class ExtendList(argparse.Action):
-    def __init__(self, *args, **kwargs):
-        super(ExtendList, self).__init__(*args, **kwargs)
-        if isinstance(self.default, list):
-            self.true_default = self.default[:]
-        else:
-            self.true_default = self.default
-
     def __call__(self, parser, namespace, values, option_string):
         list_to_extend = getattr(namespace, self.dest)
-        if self.true_default:  # if a default is defined, remove it before extending
-            for default in self.true_default:
+        if list_to_extend is self.default:
+            # if the current value is the same ref as the default,
+            # create a copy (so that extensions does not modify the
+            # default value
+            list_to_extend = self.default[:]
+        if self.default:
+            # if a default is defined, remove it before extending
+            for default in self.default:
                 list_to_extend.remove(default)
         list_to_extend.extend(values)
         setattr(namespace, self.dest, list_to_extend)

--- a/rollingpin/args.py
+++ b/rollingpin/args.py
@@ -215,7 +215,7 @@ def _add_deploy_arguments(config, parser):
     )
 
 
-def make_arg_parser(config, profile=None):
+def parse_args(config, raw_args=None, profile=None):
     prog = os.path.basename(sys.argv[0])
     parser = argparse.ArgumentParser(
         prog="{} {}".format(prog, profile) if profile else prog,
@@ -228,7 +228,15 @@ def make_arg_parser(config, profile=None):
     _add_flags(config, parser)
     _add_deploy_arguments(config, parser)
 
-    return parser
+    if not raw_args:
+        parser.print_help()
+        sys.exit(0)
+
+    args = parser.parse_args(args=raw_args)
+    for target in args.restart:
+        args.commands.append(["restart", target])
+
+    return args
 
 
 def construct_canonical_commandline(config, args):

--- a/rollingpin/elasticsearch.py
+++ b/rollingpin/elasticsearch.py
@@ -36,7 +36,7 @@ class JSONBodyProducer(object):
 
 class ElasticSearchNotifier(object):
 
-    def __init__(self, config, components, hosts, command_line, word):
+    def __init__(self, config, components, hosts, command_line, word, profile):
         self.logger = logging.getLogger(__name__)
         base_url = config["elasticsearch"]["endpoint"]
         index = config["elasticsearch"]["index"]
@@ -44,6 +44,7 @@ class ElasticSearchNotifier(object):
         self.hosts = hosts
         self.command_line = command_line
         self.deploy_name = word
+        self.profile = profile
         self.endpoint = "https://%s/%s/%s" % (base_url, index, index_type)
         self.components = components
 
@@ -102,6 +103,7 @@ class ElasticSearchNotifier(object):
         timestamp_in_milliseconds = int(time.time()) * 1000
         return {
             'id': self.deploy_name,
+            'profile': self.profile,
             'timestamp': timestamp_in_milliseconds,
             'components': self.components,
             'deployer': getpass.getuser(),
@@ -115,6 +117,7 @@ class ElasticSearchNotifier(object):
         timestamp_in_milliseconds = int(time.time()) * 1000
         return {
             'id': self.deploy_name,
+            'profile': self.profile,
             'timestamp': timestamp_in_milliseconds,
             'reason': reason,
             'components': self.components,
@@ -125,6 +128,7 @@ class ElasticSearchNotifier(object):
         timestamp_in_milliseconds = int(time.time()) * 1000
         return {
             'id': self.deploy_name,
+            'profile': self.profile,
             'timestamp': timestamp_in_milliseconds,
             'components': self.components,
             'event_type': 'deploy.end',
@@ -156,9 +160,9 @@ class ElasticSearchNotifier(object):
 
 
 def enable_elastic_search_notifications(config, event_bus, components, hosts,
-                                        command_line, word):
+                                        command_line, word, profile):
     notifier = ElasticSearchNotifier(
-        config, components, hosts, command_line, word)
+        config, components, hosts, command_line, word, profile)
     event_bus.register({
         "build.sync": notifier.on_build_sync,
         "deploy.begin": notifier.on_deploy_start,

--- a/rollingpin/main.py
+++ b/rollingpin/main.py
@@ -8,7 +8,7 @@ from twisted.internet.task import react
 
 from .elasticsearch import enable_elastic_search_notifications
 from .args import (
-    make_arg_parser,
+    parse_args,
     construct_canonical_commandline,
     make_profile_parser,
     build_action_summary,
@@ -125,11 +125,7 @@ def _load_configuration(profile_name, profile_directory=PROFILE_DIRECTORY):
 
 
 def _parse_args(config, raw_args, initial_parser):
-    arg_parser = make_arg_parser(config, initial_parser)
-    if not raw_args:
-        arg_parser.print_help()
-        sys.exit(0)
-    args = arg_parser.parse_args(args=raw_args)
+    args = parse_args(config, raw_args, initial_parser)
     args.original = construct_canonical_commandline(config, args)
     return args
 
@@ -171,8 +167,6 @@ def _main(reactor, *raw_args):
 
     config = _load_configuration(args.profile, PROFILE_DIRECTORY)
     args = _parse_args(config, raw_args, args.profile)
-    for target in args.restart:
-        args.commands.append(["restart", target])
 
     if args.test:
         print build_action_summary(config, args)

--- a/rollingpin/main.py
+++ b/rollingpin/main.py
@@ -11,6 +11,7 @@ from .args import (
     make_arg_parser,
     construct_canonical_commandline,
     make_profile_parser,
+    build_action_summary,
 )
 from .config import (
     coerce_and_validate_config,
@@ -171,7 +172,7 @@ def _main(reactor, *raw_args):
     config = _load_configuration(args.profile, PROFILE_DIRECTORY)
     args = _parse_args(config, raw_args, args.profile)
     if args.test:
-        print "rollout " + construct_canonical_commandline(config, args)
+        print build_action_summary(config, args)
         sys.exit(0)
 
     hosts = yield _select_hosts(config, args)

--- a/rollingpin/main.py
+++ b/rollingpin/main.py
@@ -164,12 +164,13 @@ def _main(reactor, *raw_args):
         initial_parser.print_help()
         sys.exit(0)
     args, raw_args = initial_parser.parse_known_args(args=raw_args)
+    profile = args.profile
 
-    config = _load_configuration(args.profile, PROFILE_DIRECTORY)
-    args = _parse_args(config, raw_args, args.profile)
+    config = _load_configuration(profile, PROFILE_DIRECTORY)
+    args = _parse_args(config, raw_args, profile)
+    print build_action_summary(config, args)
 
     if args.test:
-        print build_action_summary(config, args)
         sys.exit(0)
 
     hosts = yield _select_hosts(config, args)
@@ -190,7 +191,7 @@ def _main(reactor, *raw_args):
 
     if config["elasticsearch"]["endpoint"]:
         enable_elastic_search_notifications(
-            config, event_bus, args.components, hosts, args.original, word)
+            config, event_bus, args.components, hosts, args.original, word, profile)
 
     if os.isatty(sys.stdout.fileno()):
         HeadfulFrontend(event_bus, hosts,

--- a/rollingpin/main.py
+++ b/rollingpin/main.py
@@ -171,6 +171,9 @@ def _main(reactor, *raw_args):
 
     config = _load_configuration(args.profile, PROFILE_DIRECTORY)
     args = _parse_args(config, raw_args, args.profile)
+    for target in args.restart:
+        args.commands.append(["restart", target])
+
     if args.test:
         print build_action_summary(config, args)
         sys.exit(0)

--- a/tests/args.py
+++ b/tests/args.py
@@ -1,4 +1,5 @@
 import unittest
+import mock
 
 from rollingpin.args import (
     make_arg_parser,
@@ -185,13 +186,14 @@ class TestProfileArguments(unittest.TestCase):
             },
         }
         self.profiles = ["foo", "bar", "baz"]
-        self.profile_parser = make_profile_parser(available_profiles=self.profiles)
-        self.parser = make_arg_parser(self.config, parent_parser=self.profile_parser)
+        with mock.patch('rollingpin.args._get_available_profiles', return_value=self.profiles):
+            self.profile_parser = make_profile_parser()
+        self.parser = make_arg_parser(self.config)
 
     def test_profiles_arg(self):
         args = ["foo", "-h", "a", "-c", "test"]
 
-        profile_info, _ = self.profile_parser.parse_known_args(args=args)
+        profile_info, args = self.profile_parser.parse_known_args(args=args)
 
         full_args = self.parser.parse_args(args)
 

--- a/tests/args.py
+++ b/tests/args.py
@@ -2,7 +2,7 @@ import unittest
 import mock
 
 from rollingpin.args import (
-    make_arg_parser,
+    parse_args,
     make_profile_parser,
     construct_canonical_commandline,
 )
@@ -23,156 +23,150 @@ class TestArgumentParsing(unittest.TestCase):
                 "secret": None,
             },
         }
-        self.parser = make_arg_parser(self.config)
-
-    def parse(self, args):
-        args = self.parser.parse_args(args)
-        for target in args.restart:
-            args.commands.append(["restart", target])
-        return args
 
     # -h
     def test_no_args(self):
         with self.assertRaises(SystemExit):
-            self.parse([])
+            parse_args(self.config, [])
 
     def test_host_list(self):
-        args = self.parse(["-h", "a", "b", "c"])
+        args = parse_args(self.config, ["-h", "a", "b", "c"])
         self.assertEqual(args.host_refs, ["a", "b", "c"])
 
     def test_multiple_host_lists(self):
-        args = self.parse(["-h", "a", "-h", "b"])
+        args = parse_args(self.config, ["-h", "a", "-h", "b"])
         self.assertEqual(args.host_refs, ["a", "b"])
 
     # --parallel
     def test_parallel_default(self):
-        args = self.parse(["-h", "a"])
+        args = parse_args(self.config, ["-h", "a"])
         self.assertEqual(args.parallel, 5)
 
     def test_parallel_override(self):
-        args = self.parse(["-h", "a", "--parallel", "3"])
+        args = parse_args(self.config, ["-h", "a", "--parallel", "3"])
         self.assertEqual(args.parallel, 3)
 
     # --sleeptime
     def test_sleeptime_default(self):
-        args = self.parse(["-h", "a"])
+        args = parse_args(self.config, ["-h", "a"])
         self.assertEqual(args.sleeptime, 2)
 
     def test_sleeptime_override(self):
-        args = self.parse(["-h", "a", "--sleeptime", "1"])
+        args = parse_args(self.config, ["-h", "a", "--sleeptime", "1"])
         self.assertEqual(args.sleeptime, 1)
 
     # --startat
     def test_startat_empty(self):
-        args = self.parse(["-h", "a"])
+        args = parse_args(self.config, ["-h", "a"])
         self.assertIsNone(args.start_at)
 
     def test_startat_host(self):
-        args = self.parse(["-h", "a", "--startat", "host"])
+        args = parse_args(self.config, ["-h", "a", "--startat", "host"])
         self.assertEqual(args.start_at, "host")
 
     # --stopbefore
     def test_stopbefore_empty(self):
-        args = self.parse(["-h", "a"])
+        args = parse_args(self.config, ["-h", "a"])
         self.assertIsNone(args.stop_before)
 
     def test_stopbefore_host(self):
-        args = self.parse(["-h", "a", "--stopbefore", "host"])
+        args = parse_args(self.config, ["-h", "a", "--stopbefore", "host"])
         self.assertEqual(args.stop_before, "host")
 
     # --pauseafter
     def test_pauseafter_not_set(self):
-        args = self.parse(["-h", "a"])
+        args = parse_args(self.config, ["-h", "a"])
         self.assertEqual(args.pause_after, 1)
 
     def test_pauseafter_number(self):
-        args = self.parse(["-h", "a", "--pauseafter", "5"])
+        args = parse_args(self.config, ["-h", "a", "--pauseafter", "5"])
         self.assertEqual(args.pause_after, 5)
 
     # --list
     def test_list_default(self):
-        args = self.parse(["-h", "a"])
+        args = parse_args(self.config, ["-h", "a"])
         self.assertFalse(args.list_hosts)
 
     def test_list_flagged(self):
-        args = self.parse(["-h", "a", "--list"])
+        args = parse_args(self.config, ["-h", "a", "--list"])
         self.assertTrue(args.list_hosts)
 
     # --no-harold
     def test_harold_default(self):
-        args = self.parse(["-h", "a"])
+        args = parse_args(self.config, ["-h", "a"])
         self.assertTrue(args.notify_harold)
 
     def test_harold_flagged(self):
-        args = self.parse(["-h", "a", "--no-harold"])
+        args = parse_args(self.config, ["-h", "a", "--no-harold"])
         self.assertFalse(args.notify_harold)
 
     # -v / --verbose
     def test_verbose_default(self):
-        args = self.parse(["-h", "a"])
+        args = parse_args(self.config, ["-h", "a"])
         self.assertFalse(args.verbose_logging)
 
     def test_verbose_flagged_short(self):
-        args = self.parse(["-h", "a", "-v"])
+        args = parse_args(self.config, ["-h", "a", "-v"])
         self.assertTrue(args.verbose_logging)
 
     def test_verbose_flagged_long(self):
-        args = self.parse(["-h", "a", "--verbose"])
+        args = parse_args(self.config, ["-h", "a", "--verbose"])
         self.assertTrue(args.verbose_logging)
 
     # --dangerously-fast
     def test_dangerously_fast_default(self):
-        args = self.parse(["-h", "a"])
+        args = parse_args(self.config, ["-h", "a"])
         self.assertFalse(args.dangerously_fast)
 
     def test_dangerously_fast_on(self):
-        args = self.parse(["-h", "a", "--dangerously-fast"])
+        args = parse_args(self.config, ["-h", "a", "--dangerously-fast"])
         self.assertTrue(args.dangerously_fast)
 
     # -d
     def test_empty_deploys(self):
-        args = self.parse(["-h", "a"])
+        args = parse_args(self.config, ["-h", "a"])
         self.assertEqual(args.components, [])
 
     def test_one_deploy(self):
-        args = self.parse(["-h", "a", "-d", "comp"])
+        args = parse_args(self.config, ["-h", "a", "-d", "comp"])
         self.assertEqual(args.components, ["comp"])
 
     def test_double_deploy(self):
-        args = self.parse(["-h", "a", "-d", "comp", "comp2"])
+        args = parse_args(self.config, ["-h", "a", "-d", "comp", "comp2"])
         self.assertEqual(args.components, ["comp", "comp2"])
 
     def test_multiple_deploys(self):
-        args = self.parse(["-h", "a", "-d", "comp", "-d", "comp2"])
+        args = parse_args(self.config,
+                          ["-h", "a", "-d", "comp", "-d", "comp2"])
         self.assertEqual(args.components, ["comp", "comp2"])
 
     # -r
     def test_one_restart(self):
-        args = self.parse(["-h", "a", "-r", "all"])
+        args = parse_args(self.config, ["-h", "a", "-r", "all"])
         self.assertEqual(args.commands, [["restart", "all"]])
 
     def test_multi_restart(self):
-        args = self.parse(["-h", "a", "-r", "all", "-r", "more"])
+        args = parse_args(self.config, ["-h", "a", "-r", "all", "-r", "more"])
         self.assertEqual(
             args.commands, [["restart", "all"], ["restart", "more"]])
 
     # -c
     def test_no_commands(self):
-        args = self.parse(["-h", "a"])
+        args = parse_args(self.config, ["-h", "a"])
         self.assertEqual(args.commands, [])
 
     def test_simple_command(self):
-        args = self.parse(["-h", "a", "-c", "test"])
+        args = parse_args(self.config, ["-h", "a", "-c", "test"])
         self.assertEqual(args.commands, [["test"]])
 
     def test_command_with_args(self):
-        args = self.parse(["-h", "a", "-c", "test", "args"])
+        args = parse_args(self.config, ["-h", "a", "-c", "test", "args"])
         self.assertEqual(args.commands, [["test", "args"]])
 
     # mixup
     def test_commands_together(self):
-        args = self.parse(
-            ["-h", "a", "-c", "test", "args", "-r", "all"])
+        args = parse_args(
+            self.config, ["-h", "a", "-c", "test", "args", "-r", "all"])
         self.assertEqual(args.commands, [["test", "args"], ["restart", "all"]])
 
 
@@ -194,14 +188,13 @@ class TestProfileArguments(unittest.TestCase):
         self.profiles = ["foo", "bar", "baz"]
         with mock.patch('rollingpin.args._get_available_profiles', return_value=self.profiles):
             self.profile_parser = make_profile_parser()
-        self.parser = make_arg_parser(self.config)
 
     def test_profiles_arg(self):
         args = ["foo", "-h", "a", "-c", "test"]
 
         profile_info, args = self.profile_parser.parse_known_args(args=args)
 
-        full_args = self.parser.parse_args(args)
+        full_args = parse_args(self.config, args)
 
         self.assertEqual(profile_info.profile, "foo")
         self.assertEqual(full_args.commands, [["test"]])
@@ -228,72 +221,66 @@ class TestArgumentReconstruction(unittest.TestCase):
                 "secret": None,
             },
         }
-        self.parser = make_arg_parser(self.config)
-
-    def parse(self, args):
-        args = self.parser.parse_args(args)
-        for target in args.restart:
-            args.commands.append(["restart", target])
-        return args
 
     def test_single_host(self):
-        args = self.parse(["-h", "host"])
+        args = parse_args(self.config, ["-h", "host"])
         canonical = construct_canonical_commandline(self.config, args)
         self.assertEqual("-h host --parallel=5 --timeout=60", canonical)
 
     def test_multiple_hosts(self):
-        args = self.parse(["-h", "host", "host2"])
+        args = parse_args(self.config, ["-h", "host", "host2"])
         canonical = construct_canonical_commandline(self.config, args)
         self.assertEqual("-h host host2 --parallel=5 --timeout=60", canonical)
 
     def test_multiple_dash_hs(self):
-        args = self.parse(["-h", "host", "-h", "host2"])
+        args = parse_args(self.config, ["-h", "host", "-h", "host2"])
         canonical = construct_canonical_commandline(self.config, args)
         self.assertEqual("-h host host2 --parallel=5 --timeout=60", canonical)
 
     def test_startat(self):
-        args = self.parse(["-h", "host", "--startat", "host"])
+        args = parse_args(self.config, ["-h", "host", "--startat", "host"])
         canonical = construct_canonical_commandline(self.config, args)
         self.assertEqual(
             "-h host --startat=host --parallel=5 --timeout=60", canonical)
 
     def test_stopbefore(self):
-        args = self.parse(["-h", "host", "--stopbefore", "host"])
+        args = parse_args(self.config, ["-h", "host", "--stopbefore", "host"])
         canonical = construct_canonical_commandline(self.config, args)
         self.assertEqual(
             "-h host --stopbefore=host --parallel=5 --timeout=60", canonical)
 
     def test_parallel(self):
-        args = self.parse(["-h", "host", "--parallel", "1"])
+        args = parse_args(self.config, ["-h", "host", "--parallel", "1"])
         canonical = construct_canonical_commandline(self.config, args)
         self.assertEqual("-h host --parallel=1 --timeout=60", canonical)
 
     def test_sleeptime(self):
-        args = self.parse(["-h", "host", "--sleeptime", "5"])
+        args = parse_args(self.config, ["-h", "host", "--sleeptime", "5"])
         canonical = construct_canonical_commandline(self.config, args)
         self.assertEqual(
             "-h host --parallel=5 --sleeptime=5 --timeout=60", canonical)
 
     def test_pauseafter(self):
-        args = self.parse(["-h", "host", "--pauseafter", "2"])
+        args = parse_args(self.config, ["-h", "host", "--pauseafter", "2"])
         canonical = construct_canonical_commandline(self.config, args)
         self.assertEqual(
             "-h host --parallel=5 --pauseafter=2 --timeout=60", canonical)
 
     def test_no_harold(self):
-        args = self.parse(["-h", "host", "--no-harold"])
+        args = parse_args(self.config, ["-h", "host", "--no-harold"])
         canonical = construct_canonical_commandline(self.config, args)
         self.assertEqual(
             "-h host --parallel=5 --timeout=60 --no-harold", canonical)
 
     def test_single_deploy(self):
-        args = self.parse(["-h", "host", "-d", "component"])
+        args = parse_args(self.config, ["-h", "host", "-d", "component"])
         canonical = construct_canonical_commandline(self.config, args)
         self.assertEqual(
             "-h host --parallel=5 --timeout=60 -d component", canonical)
 
     def test_multiple_deploys(self):
-        args = self.parse(["-h", "host", "-d", "component", "component2"])
+        args = parse_args(self.config,
+                          ["-h", "host", "-d", "component", "component2"])
         canonical = construct_canonical_commandline(self.config, args)
         self.assertEqual(
             "-h host --parallel=5 --timeout=60 -d component component2",
@@ -301,8 +288,8 @@ class TestArgumentReconstruction(unittest.TestCase):
         )
 
     def test_multiple_dash_ds(self):
-        args = self.parse(
-            ["-h", "host", "-d", "component", "-d", "component2"])
+        args = parse_args(
+            self.config, ["-h", "host", "-d", "component", "-d", "component2"])
         canonical = construct_canonical_commandline(self.config, args)
         self.assertEqual(
             "-h host --parallel=5 --timeout=60 -d component component2",
@@ -310,36 +297,38 @@ class TestArgumentReconstruction(unittest.TestCase):
         )
 
     def test_restart(self):
-        args = self.parse(["-h", "host", "-r", "component"])
+        args = parse_args(self.config, ["-h", "host", "-r", "component"])
         canonical = construct_canonical_commandline(self.config, args)
         self.assertEqual(
             "-h host --parallel=5 --timeout=60 -r component", canonical)
 
     def test_multi_restart(self):
-        args = self.parse(["-h", "host", "-r", "com1", "-r", "com2"])
+        args = parse_args(self.config,
+                          ["-h", "host", "-r", "com1", "-r", "com2"])
         canonical = construct_canonical_commandline(self.config, args)
         self.assertEqual(
             "-h host --parallel=5 --timeout=60 -r com1 -r com2", canonical)
 
     def test_simple_command(self):
-        args = self.parse(["-h", "host", "-c", "cmd"])
+        args = parse_args(self.config, ["-h", "host", "-c", "cmd"])
         canonical = construct_canonical_commandline(self.config, args)
         self.assertEqual("-h host --parallel=5 --timeout=60 -c cmd", canonical)
 
     def test_command_with_args(self):
-        args = self.parse(["-h", "host", "-c", "cmd", "arg"])
+        args = parse_args(self.config, ["-h", "host", "-c", "cmd", "arg"])
         canonical = construct_canonical_commandline(self.config, args)
         self.assertEqual(
             "-h host --parallel=5 --timeout=60 -c cmd arg", canonical)
 
     def test_multiple_commands(self):
-        args = self.parse(["-h", "host", "-c", "cmd1", "-c", "cmd2"])
+        args = parse_args(self.config,
+                          ["-h", "host", "-c", "cmd1", "-c", "cmd2"])
         canonical = construct_canonical_commandline(self.config, args)
         self.assertEqual(
             "-h host --parallel=5 --timeout=60 -c cmd1 -c cmd2", canonical)
 
     def test_verbose(self):
-        args = self.parse(["-h", "host", "-v"])
+        args = parse_args(self.config, ["-h", "host", "-v"])
         canonical = construct_canonical_commandline(self.config, args)
         self.assertEqual(
             "-h host --parallel=5 --timeout=60 --verbose", canonical)

--- a/tests/args.py
+++ b/tests/args.py
@@ -25,147 +25,153 @@ class TestArgumentParsing(unittest.TestCase):
         }
         self.parser = make_arg_parser(self.config)
 
+    def parse(self, args):
+        args = self.parser.parse_args(args)
+        for target in args.restart:
+            args.commands.append(["restart", target])
+        return args
+
     # -h
     def test_no_args(self):
         with self.assertRaises(SystemExit):
-            self.parser.parse_args(args=[])
+            self.parse([])
 
     def test_host_list(self):
-        args = self.parser.parse_args(["-h", "a", "b", "c"])
+        args = self.parse(["-h", "a", "b", "c"])
         self.assertEqual(args.host_refs, ["a", "b", "c"])
 
     def test_multiple_host_lists(self):
-        args = self.parser.parse_args(["-h", "a", "-h", "b"])
+        args = self.parse(["-h", "a", "-h", "b"])
         self.assertEqual(args.host_refs, ["a", "b"])
 
     # --parallel
     def test_parallel_default(self):
-        args = self.parser.parse_args(["-h", "a"])
+        args = self.parse(["-h", "a"])
         self.assertEqual(args.parallel, 5)
 
     def test_parallel_override(self):
-        args = self.parser.parse_args(["-h", "a", "--parallel", "3"])
+        args = self.parse(["-h", "a", "--parallel", "3"])
         self.assertEqual(args.parallel, 3)
 
     # --sleeptime
     def test_sleeptime_default(self):
-        args = self.parser.parse_args(["-h", "a"])
+        args = self.parse(["-h", "a"])
         self.assertEqual(args.sleeptime, 2)
 
     def test_sleeptime_override(self):
-        args = self.parser.parse_args(["-h", "a", "--sleeptime", "1"])
+        args = self.parse(["-h", "a", "--sleeptime", "1"])
         self.assertEqual(args.sleeptime, 1)
 
     # --startat
     def test_startat_empty(self):
-        args = self.parser.parse_args(["-h", "a"])
+        args = self.parse(["-h", "a"])
         self.assertIsNone(args.start_at)
 
     def test_startat_host(self):
-        args = self.parser.parse_args(["-h", "a", "--startat", "host"])
+        args = self.parse(["-h", "a", "--startat", "host"])
         self.assertEqual(args.start_at, "host")
 
     # --stopbefore
     def test_stopbefore_empty(self):
-        args = self.parser.parse_args(["-h", "a"])
+        args = self.parse(["-h", "a"])
         self.assertIsNone(args.stop_before)
 
     def test_stopbefore_host(self):
-        args = self.parser.parse_args(["-h", "a", "--stopbefore", "host"])
+        args = self.parse(["-h", "a", "--stopbefore", "host"])
         self.assertEqual(args.stop_before, "host")
 
     # --pauseafter
     def test_pauseafter_not_set(self):
-        args = self.parser.parse_args(["-h", "a"])
+        args = self.parse(["-h", "a"])
         self.assertEqual(args.pause_after, 1)
 
     def test_pauseafter_number(self):
-        args = self.parser.parse_args(["-h", "a", "--pauseafter", "5"])
+        args = self.parse(["-h", "a", "--pauseafter", "5"])
         self.assertEqual(args.pause_after, 5)
 
     # --list
     def test_list_default(self):
-        args = self.parser.parse_args(["-h", "a"])
+        args = self.parse(["-h", "a"])
         self.assertFalse(args.list_hosts)
 
     def test_list_flagged(self):
-        args = self.parser.parse_args(["-h", "a", "--list"])
+        args = self.parse(["-h", "a", "--list"])
         self.assertTrue(args.list_hosts)
 
     # --no-harold
     def test_harold_default(self):
-        args = self.parser.parse_args(["-h", "a"])
+        args = self.parse(["-h", "a"])
         self.assertTrue(args.notify_harold)
 
     def test_harold_flagged(self):
-        args = self.parser.parse_args(["-h", "a", "--no-harold"])
+        args = self.parse(["-h", "a", "--no-harold"])
         self.assertFalse(args.notify_harold)
 
     # -v / --verbose
     def test_verbose_default(self):
-        args = self.parser.parse_args(["-h", "a"])
+        args = self.parse(["-h", "a"])
         self.assertFalse(args.verbose_logging)
 
     def test_verbose_flagged_short(self):
-        args = self.parser.parse_args(["-h", "a", "-v"])
+        args = self.parse(["-h", "a", "-v"])
         self.assertTrue(args.verbose_logging)
 
     def test_verbose_flagged_long(self):
-        args = self.parser.parse_args(["-h", "a", "--verbose"])
+        args = self.parse(["-h", "a", "--verbose"])
         self.assertTrue(args.verbose_logging)
 
     # --dangerously-fast
     def test_dangerously_fast_default(self):
-        args = self.parser.parse_args(["-h", "a"])
+        args = self.parse(["-h", "a"])
         self.assertFalse(args.dangerously_fast)
 
     def test_dangerously_fast_on(self):
-        args = self.parser.parse_args(["-h", "a", "--dangerously-fast"])
+        args = self.parse(["-h", "a", "--dangerously-fast"])
         self.assertTrue(args.dangerously_fast)
 
     # -d
     def test_empty_deploys(self):
-        args = self.parser.parse_args(["-h", "a"])
+        args = self.parse(["-h", "a"])
         self.assertEqual(args.components, [])
 
     def test_one_deploy(self):
-        args = self.parser.parse_args(["-h", "a", "-d", "comp"])
+        args = self.parse(["-h", "a", "-d", "comp"])
         self.assertEqual(args.components, ["comp"])
 
     def test_double_deploy(self):
-        args = self.parser.parse_args(["-h", "a", "-d", "comp", "comp2"])
+        args = self.parse(["-h", "a", "-d", "comp", "comp2"])
         self.assertEqual(args.components, ["comp", "comp2"])
 
     def test_multiple_deploys(self):
-        args = self.parser.parse_args(["-h", "a", "-d", "comp", "-d", "comp2"])
+        args = self.parse(["-h", "a", "-d", "comp", "-d", "comp2"])
         self.assertEqual(args.components, ["comp", "comp2"])
 
     # -r
     def test_one_restart(self):
-        args = self.parser.parse_args(["-h", "a", "-r", "all"])
+        args = self.parse(["-h", "a", "-r", "all"])
         self.assertEqual(args.commands, [["restart", "all"]])
 
     def test_multi_restart(self):
-        args = self.parser.parse_args(["-h", "a", "-r", "all", "-r", "more"])
+        args = self.parse(["-h", "a", "-r", "all", "-r", "more"])
         self.assertEqual(
             args.commands, [["restart", "all"], ["restart", "more"]])
 
     # -c
     def test_no_commands(self):
-        args = self.parser.parse_args(["-h", "a"])
+        args = self.parse(["-h", "a"])
         self.assertEqual(args.commands, [])
 
     def test_simple_command(self):
-        args = self.parser.parse_args(["-h", "a", "-c", "test"])
+        args = self.parse(["-h", "a", "-c", "test"])
         self.assertEqual(args.commands, [["test"]])
 
     def test_command_with_args(self):
-        args = self.parser.parse_args(["-h", "a", "-c", "test", "args"])
+        args = self.parse(["-h", "a", "-c", "test", "args"])
         self.assertEqual(args.commands, [["test", "args"]])
 
     # mixup
     def test_commands_together(self):
-        args = self.parser.parse_args(
+        args = self.parse(
             ["-h", "a", "-c", "test", "args", "-r", "all"])
         self.assertEqual(args.commands, [["test", "args"], ["restart", "all"]])
 
@@ -224,65 +230,70 @@ class TestArgumentReconstruction(unittest.TestCase):
         }
         self.parser = make_arg_parser(self.config)
 
+    def parse(self, args):
+        args = self.parser.parse_args(args)
+        for target in args.restart:
+            args.commands.append(["restart", target])
+        return args
+
     def test_single_host(self):
-        args = self.parser.parse_args(["-h", "host"])
+        args = self.parse(["-h", "host"])
         canonical = construct_canonical_commandline(self.config, args)
         self.assertEqual("-h host --parallel=5 --timeout=60", canonical)
 
     def test_multiple_hosts(self):
-        args = self.parser.parse_args(["-h", "host", "host2"])
+        args = self.parse(["-h", "host", "host2"])
         canonical = construct_canonical_commandline(self.config, args)
         self.assertEqual("-h host host2 --parallel=5 --timeout=60", canonical)
 
     def test_multiple_dash_hs(self):
-        args = self.parser.parse_args(["-h", "host", "-h", "host2"])
+        args = self.parse(["-h", "host", "-h", "host2"])
         canonical = construct_canonical_commandline(self.config, args)
         self.assertEqual("-h host host2 --parallel=5 --timeout=60", canonical)
 
     def test_startat(self):
-        args = self.parser.parse_args(["-h", "host", "--startat", "host"])
+        args = self.parse(["-h", "host", "--startat", "host"])
         canonical = construct_canonical_commandline(self.config, args)
         self.assertEqual(
             "-h host --startat=host --parallel=5 --timeout=60", canonical)
 
     def test_stopbefore(self):
-        args = self.parser.parse_args(["-h", "host", "--stopbefore", "host"])
+        args = self.parse(["-h", "host", "--stopbefore", "host"])
         canonical = construct_canonical_commandline(self.config, args)
         self.assertEqual(
             "-h host --stopbefore=host --parallel=5 --timeout=60", canonical)
 
     def test_parallel(self):
-        args = self.parser.parse_args(["-h", "host", "--parallel", "1"])
+        args = self.parse(["-h", "host", "--parallel", "1"])
         canonical = construct_canonical_commandline(self.config, args)
         self.assertEqual("-h host --parallel=1 --timeout=60", canonical)
 
     def test_sleeptime(self):
-        args = self.parser.parse_args(["-h", "host", "--sleeptime", "5"])
+        args = self.parse(["-h", "host", "--sleeptime", "5"])
         canonical = construct_canonical_commandline(self.config, args)
         self.assertEqual(
             "-h host --parallel=5 --sleeptime=5 --timeout=60", canonical)
 
     def test_pauseafter(self):
-        args = self.parser.parse_args(["-h", "host", "--pauseafter", "2"])
+        args = self.parse(["-h", "host", "--pauseafter", "2"])
         canonical = construct_canonical_commandline(self.config, args)
         self.assertEqual(
             "-h host --parallel=5 --pauseafter=2 --timeout=60", canonical)
 
     def test_no_harold(self):
-        args = self.parser.parse_args(["-h", "host", "--no-harold"])
+        args = self.parse(["-h", "host", "--no-harold"])
         canonical = construct_canonical_commandline(self.config, args)
         self.assertEqual(
             "-h host --parallel=5 --timeout=60 --no-harold", canonical)
 
     def test_single_deploy(self):
-        args = self.parser.parse_args(["-h", "host", "-d", "component"])
+        args = self.parse(["-h", "host", "-d", "component"])
         canonical = construct_canonical_commandline(self.config, args)
         self.assertEqual(
             "-h host --parallel=5 --timeout=60 -d component", canonical)
 
     def test_multiple_deploys(self):
-        args = self.parser.parse_args(
-            ["-h", "host", "-d", "component", "component2"])
+        args = self.parse(["-h", "host", "-d", "component", "component2"])
         canonical = construct_canonical_commandline(self.config, args)
         self.assertEqual(
             "-h host --parallel=5 --timeout=60 -d component component2",
@@ -290,7 +301,7 @@ class TestArgumentReconstruction(unittest.TestCase):
         )
 
     def test_multiple_dash_ds(self):
-        args = self.parser.parse_args(
+        args = self.parse(
             ["-h", "host", "-d", "component", "-d", "component2"])
         canonical = construct_canonical_commandline(self.config, args)
         self.assertEqual(
@@ -299,38 +310,36 @@ class TestArgumentReconstruction(unittest.TestCase):
         )
 
     def test_restart(self):
-        args = self.parser.parse_args(["-h", "host", "-r", "component"])
+        args = self.parse(["-h", "host", "-r", "component"])
         canonical = construct_canonical_commandline(self.config, args)
         self.assertEqual(
             "-h host --parallel=5 --timeout=60 -r component", canonical)
 
     def test_multi_restart(self):
-        args = self.parser.parse_args(
-            ["-h", "host", "-r", "com1", "-r", "com2"])
+        args = self.parse(["-h", "host", "-r", "com1", "-r", "com2"])
         canonical = construct_canonical_commandline(self.config, args)
         self.assertEqual(
             "-h host --parallel=5 --timeout=60 -r com1 -r com2", canonical)
 
     def test_simple_command(self):
-        args = self.parser.parse_args(["-h", "host", "-c", "cmd"])
+        args = self.parse(["-h", "host", "-c", "cmd"])
         canonical = construct_canonical_commandline(self.config, args)
         self.assertEqual("-h host --parallel=5 --timeout=60 -c cmd", canonical)
 
     def test_command_with_args(self):
-        args = self.parser.parse_args(["-h", "host", "-c", "cmd", "arg"])
+        args = self.parse(["-h", "host", "-c", "cmd", "arg"])
         canonical = construct_canonical_commandline(self.config, args)
         self.assertEqual(
             "-h host --parallel=5 --timeout=60 -c cmd arg", canonical)
 
     def test_multiple_commands(self):
-        args = self.parser.parse_args(
-            ["-h", "host", "-c", "cmd1", "-c", "cmd2"])
+        args = self.parse(["-h", "host", "-c", "cmd1", "-c", "cmd2"])
         canonical = construct_canonical_commandline(self.config, args)
         self.assertEqual(
             "-h host --parallel=5 --timeout=60 -c cmd1 -c cmd2", canonical)
 
     def test_verbose(self):
-        args = self.parser.parse_args(["-h", "host", "-v"])
+        args = self.parse(["-h", "host", "-v"])
         canonical = construct_canonical_commandline(self.config, args)
         self.assertEqual(
             "-h host --parallel=5 --timeout=60 --verbose", canonical)


### PR DESCRIPTION
Attempt to fulfill the desire for rollingpin to be aware and contextually configurable for multiple projects.  Before the internal configuration was global and the same across different project deploys.  This adds a required argument that defines a "profile" which ends up being an additional configuration file to be loaded and can provide more defaults to dictate a sane default behavior based on a profile.  Because of how the configuration loading is done, *any* config value that works in the global config can be overridden via the profile configuration.

For example, `$ rollout -h apps -d public -r all` could become `$ rollout public` where the `public` profile would be an ini file that sets defaults for the three argumented flags.

Currently (like the location of the global and user scoped config files) the profiles are hardcoded to live in `/etc/rollingpin.d/` but can be overridden with optional kwargs for the various related functions.  Three additional configuration options have been added for setting default values for the `-h`, `-c`, and `-r` args, more can be added.