### PR TITLE
Prompt users with warnings if deploying in unsafe conditions

### DIFF
--- a/rollingpin/deploy.py
+++ b/rollingpin/deploy.py
@@ -122,6 +122,12 @@ class Deployer(object):
     @inlineCallbacks
     def run_deploy(self, hosts, components, commands):
         try:
+            yield self.event_bus.trigger("deploy.precheck")
+        except AbortDeploy as e:
+            yield self.abort(str(e))
+            return
+
+        try:
             self.transport.initialize()
         except TransportError as e:
             raise DeployError("could not initialize transport: %s" % e)

--- a/rollingpin/main.py
+++ b/rollingpin/main.py
@@ -177,8 +177,8 @@ def _main(reactor, *raw_args):
             config, event_bus, args.components, hosts, args.original, word)
 
     if os.isatty(sys.stdout.fileno()):
-        HeadfulFrontend(event_bus, hosts,
-                        args.verbose_logging, args.pause_after)
+        HeadfulFrontend(event_bus, hosts, args.verbose_logging,
+                        args.pause_after, config)
     else:
         HeadlessFrontend(event_bus, hosts, args.verbose_logging)
 

--- a/rollingpin/status.py
+++ b/rollingpin/status.py
@@ -1,0 +1,65 @@
+import json
+import logging
+import posixpath
+import urlparse
+
+from twisted.internet import reactor
+from twisted.internet.defer import inlineCallbacks, returnValue, CancelledError
+from twisted.web.client import Agent, readBody
+
+
+TIMEOUT = 5  # seconds
+
+
+# this is the "safe" response so if we're not configured or something goes
+# wrong we'll just not prompt the user so deploys aren't blocked.
+SAFE_DEFAULT = {"time_status": "work_time", "busy": False}
+
+
+@inlineCallbacks
+def _do_status_http_request(harold_base_url):
+    base_url = urlparse.urlparse(harold_base_url)
+    path = posixpath.join(base_url.path, "harold/deploy/status")
+    url = urlparse.urlunparse((
+        base_url.scheme,
+        base_url.netloc,
+        path,
+        None,
+        None,
+        None
+    ))
+
+    agent = Agent(reactor)
+    response = yield agent.request("GET", url)
+    if response.code != 200:
+        raise Exception("harold responded with an error: %d" % response.code)
+    body = yield readBody(response)
+    returnValue(json.loads(body))
+
+
+@inlineCallbacks
+def fetch_deploy_status(config):
+    harold_base_url = config["harold"]["base-url"]
+    if not harold_base_url:
+        returnValue(SAFE_DEFAULT)
+
+    fetch_req = _do_status_http_request(harold_base_url)
+
+    # give the request a few seconds and bail out if it takes too long
+    timeout = reactor.callLater(TIMEOUT, fetch_req.cancel)
+    def cancel_timeout(passthrough):
+        if timeout.active():
+            timeout.cancel()
+        return passthrough
+    fetch_req.addBoth(cancel_timeout)
+
+    try:
+        result = yield fetch_req
+    except CancelledError:
+        logging.warning("failed to fetch deploy status: timed out")
+        returnValue(SAFE_DEFAULT)
+    except Exception as exc:
+        logging.warning("failed to fetch deploy status: %s", exc)
+        returnValue(SAFE_DEFAULT)
+
+    returnValue(result)

--- a/rollingpin/status.py
+++ b/rollingpin/status.py
@@ -47,6 +47,7 @@ def fetch_deploy_status(config):
 
     # give the request a few seconds and bail out if it takes too long
     timeout = reactor.callLater(TIMEOUT_SECONDS, fetch_req.cancel)
+
     def cancel_timeout(passthrough):
         if timeout.active():
             timeout.cancel()

--- a/rollingpin/status.py
+++ b/rollingpin/status.py
@@ -8,7 +8,7 @@ from twisted.internet.defer import inlineCallbacks, returnValue, CancelledError
 from twisted.web.client import Agent, readBody
 
 
-TIMEOUT = 5  # seconds
+TIMEOUT_SECONDS = 5
 
 
 # this is the "safe" response so if we're not configured or something goes
@@ -46,7 +46,7 @@ def fetch_deploy_status(config):
     fetch_req = _do_status_http_request(harold_base_url)
 
     # give the request a few seconds and bail out if it takes too long
-    timeout = reactor.callLater(TIMEOUT, fetch_req.cancel)
+    timeout = reactor.callLater(TIMEOUT_SECONDS, fetch_req.cancel)
     def cancel_timeout(passthrough):
         if timeout.active():
             timeout.cancel()


### PR DESCRIPTION
This checks against a new endpoint in Harold to see if it's currently
outside of sanctioned deploy times or other deploys are in progress and
displays a warning prompt to the user if either condition applies. This
is intended to give a little extra indication that extra consideration
should be applied and not a hard rule.

We'll want to only land this after @jdost's project profile thing as currently
all the backend projects are sharing a harold improperly.

![screenshot from 2017-08-23 13-23-17](https://user-images.githubusercontent.com/338853/29636641-3f323320-8806-11e7-806e-5d3c8030173f.png)

Feel free to bikeshed wording, I tried to go for "admonishment without being too judgy" and didn't want to get too specific on our policies since this is a general tool.

Here's the relevant harold commit if curious: https://github.com/spladug/harold/commit/9c838a94ca588afb1e731e731760484ed4f18cb5
