### PR TITLE
Fix AlreadyCalledError in case of timeout.

### DIFF
--- a/rollingpin/transports/ssh.py
+++ b/rollingpin/transports/ssh.py
@@ -228,6 +228,13 @@ class _CommandChannel(SSHChannel):
         self.reason = SignalError(signal)
 
     def closed(self):
+
+        # The `finished` callback may have been already called if there was a
+        # timeout issue.  If we try to call it again, it will fail loudly with
+        # a twisted `AlreadyCalledError` exception.
+        if self.finished.called:
+            return
+
         if not self.reason:
             self.result.seek(0)
             try:


### PR DESCRIPTION
👓  @spladug 

Sorry it took me a bit on this, was caught up in other things.  I haven't tested this yet -- still need to come up with a reproducible case locally since this wasn't happening for me in the case of a timeout.  Obviously I won't ship this unless I can get the failure working consistently and prove this fixes it.