### PR TITLE
Add hold status to pre-deploy checks

### DIFF
--- a/rollingpin/frontends.py
+++ b/rollingpin/frontends.py
@@ -270,9 +270,9 @@ class HeadfulFrontend(HeadlessFrontend):
 
         bad_time = status["time_status"] not in ("work_time", "cleanup_time")
         deploy_in_progress = status["busy"]
-        hold = status.get("hold")
+        hold_reason = status.get("hold")
 
-        if bad_time or deploy_in_progress or hold:
+        if bad_time or deploy_in_progress or hold_reason:
             print colorize("*** WARNING ***", Color.BOLD(Color.RED))
 
             reasons = []
@@ -280,8 +280,8 @@ class HeadfulFrontend(HeadlessFrontend):
                 reasons.append("it is currently outside of normal deploy hours")
             if deploy_in_progress:
                 reasons.append("another deploy is currently happening")
-            if hold:
-                reasons.append("deploys are on hold: " + hold)
+            if hold_reason:
+                reasons.append("deploys are on hold: " + hold_reason)
 
             print "This may not be a good time to do a deploy:",
             print ", and ".join(colorize(r, Color.BOLD(Color.YELLOW)) for r in reasons) + ".",

--- a/rollingpin/frontends.py
+++ b/rollingpin/frontends.py
@@ -270,8 +270,9 @@ class HeadfulFrontend(HeadlessFrontend):
 
         bad_time = status["time_status"] not in ("work_time", "cleanup_time")
         deploy_in_progress = status["busy"]
+        hold = status.get("hold")
 
-        if bad_time or deploy_in_progress:
+        if bad_time or deploy_in_progress or hold:
             print colorize("*** WARNING ***", Color.BOLD(Color.RED))
 
             reasons = []
@@ -279,6 +280,8 @@ class HeadfulFrontend(HeadlessFrontend):
                 reasons.append("it is currently outside of normal deploy hours")
             if deploy_in_progress:
                 reasons.append("another deploy is currently happening")
+            if hold:
+                reasons.append("deploys are on hold: " + hold)
 
             print "This may not be a good time to do a deploy:",
             print ", and ".join(colorize(r, Color.BOLD(Color.YELLOW)) for r in reasons) + ".",

--- a/rollingpin/status.py
+++ b/rollingpin/status.py
@@ -1,11 +1,15 @@
+import hashlib
+import hmac
 import json
 import logging
 import posixpath
+import time
 import urlparse
 
 from twisted.internet import reactor
 from twisted.internet.defer import inlineCallbacks, returnValue, CancelledError
 from twisted.web.client import Agent, readBody
+from twisted.web.http_headers import Headers
 
 
 TIMEOUT_SECONDS = 5
@@ -13,11 +17,15 @@ TIMEOUT_SECONDS = 5
 
 # this is the "safe" response so if we're not configured or something goes
 # wrong we'll just not prompt the user so deploys aren't blocked.
-SAFE_DEFAULT = {"time_status": "work_time", "busy": False}
+SAFE_DEFAULT = {
+    "time_status": "work_time",
+    "busy": False,
+    "hold": None,
+}
 
 
 @inlineCallbacks
-def _do_status_http_request(harold_base_url):
+def _do_status_http_request(harold_base_url, harold_secret):
     base_url = urlparse.urlparse(harold_base_url)
     path = posixpath.join(base_url.path, "harold/deploy/status")
     url = urlparse.urlunparse((
@@ -29,8 +37,16 @@ def _do_status_http_request(harold_base_url):
         None
     ))
 
+    now = str(int(time.time()))
+    signature = hmac.new(harold_secret, now, hashlib.sha256).hexdigest()
+    signature_header = "%s:%s" % (now, signature)
+
     agent = Agent(reactor)
-    response = yield agent.request("GET", url)
+    headers = Headers({
+        "User-Agent": ["rollingpin"],
+        "X-Signature": [signature_header],
+    })
+    response = yield agent.request("GET", url, headers)
     if response.code != 200:
         raise Exception("harold responded with an error: %d" % response.code)
     body = yield readBody(response)
@@ -40,10 +56,11 @@ def _do_status_http_request(harold_base_url):
 @inlineCallbacks
 def fetch_deploy_status(config):
     harold_base_url = config["harold"]["base-url"]
-    if not harold_base_url:
+    harold_secret = config["harold"]["hmac-secret"]
+    if not harold_base_url or not harold_secret:
         returnValue(SAFE_DEFAULT)
 
-    fetch_req = _do_status_http_request(harold_base_url)
+    fetch_req = _do_status_http_request(harold_base_url, harold_secret)
 
     # give the request a few seconds and bail out if it takes too long
     timeout = reactor.callLater(TIMEOUT_SECONDS, fetch_req.cancel)


### PR DESCRIPTION
![screenshot from 2017-10-10 10-36-55](https://user-images.githubusercontent.com/338853/31401244-32681166-ada7-11e7-8ba3-0e69b3e0d75e.png)

Relevant harold changes are [here](https://github.com/spladug/harold/compare/hold-status). I'll roll this out first since then rollout will start sending authentication headers (and will safely ignore a missing hold status in response). Then I'll deploy the harold change to require the authentication and add hold status.