### PR TITLE
 Report failed hosts during deploys to harold rather than user

### DIFF
--- a/example.ini
+++ b/example.ini
@@ -48,7 +48,7 @@ secret =
 
 [elasticsearch]
 ; elasticsearch is used to store deploy metadata
-endpoint = metric.com:1234
+endpoint =
 ; name of the ES index where metadata should go
 index = deploy-*
 ; index type that the deploy metadata belongs to

--- a/rollingpin/frontends.py
+++ b/rollingpin/frontends.py
@@ -140,7 +140,7 @@ class HeadlessFrontend(object):
         if host in self.host_results:
             self.host_results[host]['status'] = "success"
             self.host_results[host]['results'] = results
-            print colorize("*** %d%% done" % self.percent_complete(), Color.GREEN)  # noqa
+            self._print_percent_complete()
 
     def on_host_abort(self, host, error, should_be_alive):
         if host in self.host_results:
@@ -148,37 +148,17 @@ class HeadlessFrontend(object):
                 self.host_results[host]['status'] = "error"
             else:
                 self.host_results[host]['status'] = "warning"
+        self._print_percent_complete()
+
+    def _print_percent_complete(self):
+        print colorize("*** %d%% done" % self.percent_complete(), Color.GREEN)
 
     def on_deploy_abort(self, reason):
         print colorize(
             "*** deploy aborted: %s" % reason, Color.BOLD(Color.RED))
 
     def on_deploy_end(self):
-        by_result = collections.defaultdict(list)
-        for host, result in self.host_results.iteritems():
-            by_result[result['status']].append(host)
-
         print colorize("*** deploy complete!", Color.BOLD(Color.GREEN))
-
-        if by_result["warning"]:
-            warning_hosts = by_result["warning"]
-            print("*** encountered errors on %d possibly terminated "
-                  "hosts:" % len(warning_hosts))
-            print "      ", " ".join(
-                colorize(host, Color.YELLOW)
-                for host in sorted_nicely(host.name for host in warning_hosts))
-
-        if by_result["error"]:
-            error_hosts = by_result["error"]
-            print("*** encountered unexpected errors on %d "
-                  "healthy hosts:" % len(error_hosts))
-            print "      ", " ".join(
-                colorize(host, Color.RED)
-                for host in sorted_nicely(host.name for host in error_hosts))
-
-        successful_hosts = len(by_result["success"])
-        print "*** processed %d hosts successfully" % successful_hosts
-
         elapsed = time.time() - self.start_time
         print "*** elapsed time: %d seconds" % elapsed
 

--- a/rollingpin/transports/mock.py
+++ b/rollingpin/transports/mock.py
@@ -24,7 +24,7 @@ class MockTransport(Transport):
 
 class MockTransportConnection(TransportConnection):
     @inlineCallbacks
-    def execute(self, log, command):
+    def execute(self, log, command, timeout=0):
         command, args = command[0], command[1:]
         result = {}
 

--- a/rollingpin/transports/mock.py
+++ b/rollingpin/transports/mock.py
@@ -41,10 +41,12 @@ class MockTransportConnection(TransportConnection):
             log.debug("MOCK: git checkout origin/master")
         elif command == "restart":
             log.debug("MOCK: /sbin/initctl emit restart")
+        elif command == "wait-until-components-ready":
+            log.debug("MOCK: /sbin/initctl emit wait-until-components-ready")
+            yield sleep(random.random() * 1)
         else:
             raise CommandFailed("unknown command %r" % command)
 
-        yield sleep(random.random() * 3)
         returnValue(result)
 
     def disconnect(self):


### PR DESCRIPTION
This lets us alert on them instead of bugging users and relying on them
to report it when necessary.

There are also a few fixes to local testing here broken out into separate commits.