### PR TITLE
Sort hosts before interleaving

### DIFF
--- a/rollingpin/frontends.py
+++ b/rollingpin/frontends.py
@@ -18,7 +18,6 @@ from twisted.internet.stdio import StandardIO
 
 from .deploy import AbortDeploy
 from .status import fetch_deploy_status
-from .utils import sorted_nicely
 
 
 class Color(object):

--- a/rollingpin/main.py
+++ b/rollingpin/main.py
@@ -34,7 +34,7 @@ from .hostsources import HostSourceError
 from .graphite import enable_graphite_notifications
 from .log import log_to_file
 from .providers import get_provider, UnknownProviderError
-from .utils import interleaved, b36encode
+from .utils import interleaved, b36encode, sorted_nicely
 
 
 PROFILE_DIRECTORY = "/etc/rollingpin.d/"
@@ -140,9 +140,11 @@ def _select_hosts(config, args):
         print_error("could not fetch host list: {}", e)
         sys.exit(1)
 
+    all_hosts = sorted_nicely(all_hosts_unsorted, key=lambda h: h.name)
+
     try:
         full_hostlist = resolve_hostlist(
-            args.host_refs, all_hosts_unsorted, config["aliases"])
+            args.host_refs, all_hosts, config["aliases"])
         selected_hosts = restrict_hostlist(
             full_hostlist, args.start_at, args.stop_before)
     except HostlistError as e:

--- a/rollingpin/utils.py
+++ b/rollingpin/utils.py
@@ -38,7 +38,7 @@ def sleep(seconds):
 valid_push_word = re.compile("^[a-z:]{5,}$")
 
 
-def sorted_nicely(iterable):
+def sorted_nicely(iterable, key):
     """Sort strings with embedded numbers in them the way humans would expect.
 
     http://nedbatchelder.com/blog/200712/human_sorting.html#comments
@@ -51,8 +51,8 @@ def sorted_nicely(iterable):
         except ValueError:
             return maybe_int
 
-    def alphanum_key(key):
-        return [tryint(c) for c in re.split("([0-9]+)", key)]
+    def alphanum_key(item):
+        return [tryint(c) for c in re.split("([0-9]+)", key(item))]
 
     return sorted(iterable, key=alphanum_key)
 


### PR DESCRIPTION
This ensures that we get a stable ordering so that reverts hit the same
hosts first. This was a regression.