### PR TITLE
Overhaul the UI during deploys

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,35 @@ on the hosts matched by the `myhosts ` alias.
 
 Development
 -----
-For local dev, you can run all tests/lint in a local docker container by:
+
+A `Vagrantfile` is included which sets up a testing environment that uses a
+mock hostsource and transport so that you can simulate deploys to non-existent
+hosts.
+
+```
+# launch the environment
+host$ vagrant up
+host$ vagrant ssh
+
+# "deploy" to the full list of servers
+rollingpin$ rollout test
+
+# "deploy" to smaller subsets of servers
+rollingpin$ rollout test -h common
+rollingpin$ rollout test -h medium
+rollingpin$ rollout test -h rare
+rollingpin$ rollout test -h singular
+
+# run the test suite
+rollingpin$ cd rollingpin/
+rollingpin$ python setup.py test
+```
+
+You can also run the test and lint suites in a Docker container:
+
 ```bash
 docker build . -t rollingpin:test && docker run --rm rollingpin:test
 ```
-
 
 [1]: http://i.imgur.com/66Nr9Wo.jpg
 [2]: https://github.com/spladug/harold

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,18 @@
+Vagrant.configure(2) do |config|
+  config.vm.box = "trusty-cloud-image"
+  config.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
+  config.vm.network "private_network", type: "dhcp"
+  config.vm.hostname = "rollingpin.local"
+
+  config.vm.provision :puppet do |puppet|
+    puppet.manifests_path = "./puppet"
+    puppet.manifest_file = "init.pp"
+    puppet.module_path = "./puppet/modules"
+    puppet.facter = {
+      "user" => "vagrant",
+      "project_path" => "/home/vagrant/rollingpin",
+    }
+  end
+
+  config.vm.synced_folder  ".", "/home/vagrant/rollingpin"
+end

--- a/example.ini
+++ b/example.ini
@@ -23,7 +23,29 @@ execution-timeout = 60
 ; the other built in provider is "autoscaler". additional providers may be
 ; implemented and discovered with the pkg_resources entry points system.
 provider = mock
-hosts = app-01 app-02 app-03 job-01 job-02 uncool-01
+hosts = common-01
+        common-02
+        common-03
+        common-04
+        common-05
+        common-06
+        common-07
+        common-08
+        common-09
+        common-10
+        common-11
+        common-12
+        medium-01
+        medium-02
+        medium-03
+        medium-04
+        medium-05
+        medium-06
+        medium-07
+        rare-01
+        rare-02
+        rare-03
+        singular
 
 [transport]
 ; this is a simple testing provider
@@ -61,5 +83,7 @@ endpoint =
 
 [aliases]
 ; glob patterns for aliasing groups of servers
-apps = app-* %(jobs)s
-jobs = job-*
+all = %(common)s %(medium)s %(rare)s singular
+common = common-*
+medium = medium-*
+rare = rare-*

--- a/example_profile.ini
+++ b/example_profile.ini
@@ -7,7 +7,7 @@
 
 [deploy]
 ; this sets a default set of hosts to apply to (default for the '-h' argument)
-default-hosts = apps
+default-hosts = all
 
 ; this sets a default set of components to deploy (default for the '-c' argument)
 default-components = rollingpin

--- a/puppet/README.md
+++ b/puppet/README.md
@@ -1,0 +1,7 @@
+This directory contains puppet manifests that configure a development
+environment for rollingpin.
+
+These manifests are applied automatically if you use Vagrant. To apply them
+manually, run the following from the root of the project:
+
+    sudo FACTER_user=$USER FACTER_project_path=$PWD puppet apply --modulepath puppet/modules puppet/init.pp

--- a/puppet/init.pp
+++ b/puppet/init.pp
@@ -1,0 +1,17 @@
+Exec { path => [ '/usr/bin', '/usr/sbin', '/bin', '/usr/local/bin' ] }
+
+exec { 'update apt cache':
+  command     => 'apt-get update',
+  refreshonly => true,
+}
+
+# make updating the apt cache an implicit requirement for all packages
+Exec['update apt cache'] -> Package<| |>
+
+# this makes your daemon accessible on rollingpin.local
+# automatically via mDNS.
+package { 'avahi-daemon':
+  ensure => installed,
+}
+
+include rollingpin

--- a/puppet/modules/rollingpin/manifests/init.pp
+++ b/puppet/modules/rollingpin/manifests/init.pp
@@ -1,0 +1,59 @@
+class rollingpin {
+  exec { 'add reddit ppa':
+    command => 'add-apt-repository -y ppa:reddit/ppa',
+    unless  => 'apt-cache policy | grep reddit/ppa',
+    notify  => Exec['update apt cache'],
+  }
+
+  $dependencies = [
+    'pep8',
+    'python',
+    'python-coverage',
+    'python-mock',
+    'python-twisted',
+    'python-txzookeeper',
+  ]
+
+  package { $dependencies:
+    ensure => installed,
+    before => Exec['build app'],
+  }
+
+  exec { 'build app':
+    user    => $::user,
+    cwd     => $::project_path,
+    command => 'python setup.py build',
+    before  => Exec['install app'],
+  }
+
+  exec { 'install app':
+    user    => $::user,
+    cwd     => $::project_path,
+    command => 'python setup.py develop --user',
+  }
+
+  file { '/etc/rollingpin.ini':
+    ensure => link,
+    target => "${::project_path}/example.ini",
+  }
+
+  file { '/etc/rollingpin.d':
+    ensure => directory,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755',
+  }
+
+  file { '/etc/rollingpin.d/test.ini':
+    ensure => link,
+    target => "${::project_path}/example_profile.ini",
+  }
+
+  file { '/etc/profile.d/local-bin.sh':
+    ensure  => file,
+    content => 'export PATH=$PATH:~/.local/bin',
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+  }
+}

--- a/rollingpin/args.py
+++ b/rollingpin/args.py
@@ -44,20 +44,6 @@ def _add_selection_arguments(config, parser):
         dest="host_refs",
     )
 
-    selection_group.add_argument(
-        "--startat",
-        help="skip to this position in the host list",
-        metavar="HOST",
-        dest="start_at",
-    )
-
-    selection_group.add_argument(
-        "--stopbefore",
-        help="end the deploy when this host is reached",
-        metavar="HOST",
-        dest="stop_before",
-    )
-
 
 def _add_iteration_arguments(config, parser):
     iteration_group = parser.add_argument_group("host iteration")
@@ -249,13 +235,6 @@ def construct_canonical_commandline(config, args):
 
     arg_list.append("-h")
     arg_list.extend(args.host_refs)
-
-    if args.start_at:
-        arg_list.append("--startat=%s" % args.start_at)
-
-    if args.stop_before:
-        arg_list.append("--stopbefore=%s" % args.stop_before)
-
     arg_list.append("--parallel=%d" % args.parallel)
 
     sleeptime_default = config["deploy"]["default-sleeptime"]

--- a/rollingpin/args.py
+++ b/rollingpin/args.py
@@ -3,9 +3,6 @@ import os
 import sys
 
 
-PAUSEAFTER_DEFAULT = 1
-
-
 class ExtendList(argparse.Action):
     def __call__(self, parser, namespace, values, option_string):
         list_to_extend = getattr(namespace, self.dest)
@@ -87,15 +84,6 @@ def _add_iteration_arguments(config, parser):
         dest="sleeptime",
     )
 
-    iteration_group.add_argument(
-        "--pauseafter",
-        default=PAUSEAFTER_DEFAULT,
-        type=int,
-        help="pause after COUNT hosts",
-        metavar="COUNT",
-        dest="pause_after",
-    )
-
     timeout_default = config["deploy"]["execution-timeout"]
     iteration_group.add_argument(
         "--timeout",
@@ -137,9 +125,7 @@ def _add_flags(config, parser):
         "--dangerously-fast",
         action="store_true",
         default=False,
-        help=("Don't wait on service restarts."
-              "VERY dangerous when combined with a high parallel host count"
-              ),
+        help="Deploy to all servers immediately and don't wait on restarts.",
         dest="dangerously_fast",
     )
 
@@ -275,9 +261,6 @@ def construct_canonical_commandline(config, args):
     sleeptime_default = config["deploy"]["default-sleeptime"]
     if args.sleeptime != sleeptime_default:
         arg_list.append("--sleeptime=%d" % args.sleeptime)
-
-    if args.pause_after != PAUSEAFTER_DEFAULT:
-        arg_list.append("--pauseafter=%d" % args.pause_after)
 
     if args.timeout is not None:
         arg_list.append("--timeout=%d" % args.timeout)

--- a/rollingpin/args.py
+++ b/rollingpin/args.py
@@ -306,8 +306,8 @@ def construct_canonical_commandline(config, args):
 
 
 def build_action_summary(config, args):
-    expanded_command = os.path.basename(sys.argv[0]) + " " \
-            + construct_canonical_commandline(config, args)
+    expanded_command = (os.path.basename(sys.argv[0]) + " " +
+                        construct_canonical_commandline(config, args))
 
     summary_points = []
 

--- a/rollingpin/deploy.py
+++ b/rollingpin/deploy.py
@@ -197,7 +197,6 @@ class Deployer(object):
                         ["restart" in val for val in commands])
                     if restarting_component and not self.dangerously_fast:
                         commands.append(["wait-until-components-ready"])
-
                 except Exception:
                     traceback.print_exc()
                     raise DeployError("unexpected error in sync/build")
@@ -227,7 +226,7 @@ class Deployer(object):
                 host_deploys.append(deferred)
 
                 yield self.event_bus.trigger(
-                    "deploy.enqueue", deploys=host_deploys)
+                    "deploy.enqueue", host=host, deferred=deferred)
             yield DeferredList(host_deploys)
         except (DeployError, AbortDeploy, TransportError) as e:
             yield self.abort(str(e))

--- a/rollingpin/frontends.py
+++ b/rollingpin/frontends.py
@@ -478,14 +478,17 @@ class HeadfulFrontend(HeadlessFrontend):
 
             print "This may not be a good time to do a deploy:",
             print ", and ".join(colorize(r, Color.BOLD(Color.YELLOW)) for r in reasons) + ".",
-            print "Are you sure you want to proceed with the deploy? [y/n]"
+            print
 
-            while True:
-                char = yield self.console_input.read_character()
-                if char == "y":
-                    break
-                elif char == "n":
-                    raise AbortDeploy("cancelled")
+            choice = yield prompt_choice(self.console_input, (
+                "whoops! never mind, [a]bort",
+                "i have manager approval, [d]eploy anyway",
+            ))
+
+            if choice == "a":
+                raise AbortDeploy("aborted at precheck")
+            elif choice == "d":
+                return
 
     @inlineCallbacks
     def on_enqueue(self, host, deferred):

--- a/rollingpin/frontends.py
+++ b/rollingpin/frontends.py
@@ -489,6 +489,16 @@ class HeadfulFrontend(HeadlessFrontend):
                 raise AbortDeploy("aborted at precheck")
             elif choice == "d":
                 return
+        else:
+            choice = yield prompt_choice(self.console_input, (
+                "those instructions don't look right, [a]bort!",
+                "looks good, [s]tart the deploy!",
+            ))
+
+            if choice == "a":
+                raise AbortDeploy("aborted at deploy description")
+            elif choice == "s":
+                return
 
     @inlineCallbacks
     def on_enqueue(self, host, deferred):

--- a/rollingpin/harold.py
+++ b/rollingpin/harold.py
@@ -131,5 +131,7 @@ class HaroldNotifier(object):
 
 def enable_harold_notifications(
         word, config,  event_bus, hosts, command_line, log_path):
+    if not (config["harold"]["base-url"] and config["harold"]["hmac-secret"]):
+        return
     harold = HaroldWhisperer(config)
     HaroldNotifier(harold, event_bus, word, hosts, command_line, log_path)

--- a/rollingpin/hostsources/mock.py
+++ b/rollingpin/hostsources/mock.py
@@ -17,7 +17,7 @@ class MockHostSource(HostSource):
         self.hosts = config["hostsource"]["hosts"].split()
 
     def get_hosts(self):
-        return succeed(Host(name, name, name, "")
+        return succeed(Host(name, name, name, name.split("-")[0])
                        for name in self.hosts)
 
     def should_be_alive(self, host):

--- a/rollingpin/hostsources/mock.py
+++ b/rollingpin/hostsources/mock.py
@@ -17,8 +17,8 @@ class MockHostSource(HostSource):
         self.hosts = config["hostsource"]["hosts"].split()
 
     def get_hosts(self):
-        return succeed(Host(name, name, name, name.split("-")[0])
-                       for name in self.hosts)
+        return succeed([Host(name, name, name, name.split("-")[0])
+                        for name in self.hosts])
 
     def should_be_alive(self, host):
         return succeed(random.choice((True, True, True, False)))

--- a/rollingpin/main.py
+++ b/rollingpin/main.py
@@ -181,7 +181,7 @@ def _main(reactor, *raw_args):
     args = _parse_args(config, raw_args, profile)
 
     if not args.list_hosts:
-        print build_action_summary(config, args)
+        print build_action_summary(config, args),
 
     if args.test:
         sys.exit(0)

--- a/rollingpin/main.py
+++ b/rollingpin/main.py
@@ -196,9 +196,8 @@ def _main(reactor, *raw_args):
         enable_elastic_search_notifications(
             config, event_bus, args.components, hosts, args.original, word, profile)
 
-    if os.isatty(sys.stdout.fileno()):
-        HeadfulFrontend(event_bus, hosts, args.verbose_logging,
-                        args.pause_after, config)
+    if not args.dangerously_fast and os.isatty(sys.stdout.fileno()):
+        HeadfulFrontend(event_bus, hosts, args.verbose_logging, config)
     else:
         HeadlessFrontend(event_bus, hosts, args.verbose_logging)
 

--- a/rollingpin/transports/mock.py
+++ b/rollingpin/transports/mock.py
@@ -16,7 +16,7 @@ class MockTransport(Transport):
 
     @inlineCallbacks
     def connect_to(self, host):
-        yield sleep(random.random() * 2)
+        yield sleep(random.random())
 
         connection = MockTransportConnection()
         returnValue(connection)

--- a/rollingpin/transports/mock.py
+++ b/rollingpin/transports/mock.py
@@ -44,6 +44,13 @@ class MockTransportConnection(TransportConnection):
         elif command == "wait-until-components-ready":
             log.debug("MOCK: /sbin/initctl emit wait-until-components-ready")
             yield sleep(random.random() * 1)
+        elif command == "components":
+            result["components"] = {
+                "example": {
+                    "fbcedda5b56618db18426f90a06f1f62984b95e8": 3,
+                    "7af8fe6294eab579c022b200388e886a348f05ac": 5,
+                },
+            }
         else:
             raise CommandFailed("unknown command %r" % command)
 

--- a/rollingpin/utils.py
+++ b/rollingpin/utils.py
@@ -1,8 +1,6 @@
 import collections
 import contextlib
 import math
-import os
-import random
 import re
 
 from twisted.internet import reactor

--- a/rollingpin/utils.py
+++ b/rollingpin/utils.py
@@ -36,25 +36,6 @@ def sleep(seconds):
 valid_push_word = re.compile("^[a-z:]{5,}$")
 
 
-def sorted_nicely(iterable):
-    """Sort strings with embedded numbers in them the way humans would expect.
-
-    http://nedbatchelder.com/blog/200712/human_sorting.html#comments
-
-    """
-
-    def tryint(maybe_int):
-        try:
-            return int(maybe_int)
-        except ValueError:
-            return maybe_int
-
-    def alphanum_key(key):
-        return [tryint(c) for c in re.split("([0-9]+)", key)]
-
-    return sorted(iterable, key=alphanum_key)
-
-
 @inlineCallbacks
 def parallel_map(iterable, fn, *args, **kwargs):
     deferreds = []
@@ -82,6 +63,9 @@ def interleaved(items, key):
     the same time due to an unlucky host ordering.
 
     """
+    if not items:
+        return []
+
     grouped = collections.defaultdict(list)
     for item in items:
         grouped[key(item)].append(item)

--- a/tests/args.py
+++ b/tests/args.py
@@ -73,15 +73,6 @@ class TestArgumentParsing(unittest.TestCase):
         args = parse_args(self.config, ["-h", "a", "--stopbefore", "host"])
         self.assertEqual(args.stop_before, "host")
 
-    # --pauseafter
-    def test_pauseafter_not_set(self):
-        args = parse_args(self.config, ["-h", "a"])
-        self.assertEqual(args.pause_after, 1)
-
-    def test_pauseafter_number(self):
-        args = parse_args(self.config, ["-h", "a", "--pauseafter", "5"])
-        self.assertEqual(args.pause_after, 5)
-
     # --list
     def test_list_default(self):
         args = parse_args(self.config, ["-h", "a"])
@@ -259,12 +250,6 @@ class TestArgumentReconstruction(unittest.TestCase):
         canonical = construct_canonical_commandline(self.config, args)
         self.assertEqual(
             "-h host --parallel=5 --sleeptime=5 --timeout=60", canonical)
-
-    def test_pauseafter(self):
-        args = parse_args(self.config, ["-h", "host", "--pauseafter", "2"])
-        canonical = construct_canonical_commandline(self.config, args)
-        self.assertEqual(
-            "-h host --parallel=5 --pauseafter=2 --timeout=60", canonical)
 
     def test_no_harold(self):
         args = parse_args(self.config, ["-h", "host", "--really-no-harold"])

--- a/tests/args.py
+++ b/tests/args.py
@@ -55,24 +55,6 @@ class TestArgumentParsing(unittest.TestCase):
         args = parse_args(self.config, ["-h", "a", "--sleeptime", "1"])
         self.assertEqual(args.sleeptime, 1)
 
-    # --startat
-    def test_startat_empty(self):
-        args = parse_args(self.config, ["-h", "a"])
-        self.assertIsNone(args.start_at)
-
-    def test_startat_host(self):
-        args = parse_args(self.config, ["-h", "a", "--startat", "host"])
-        self.assertEqual(args.start_at, "host")
-
-    # --stopbefore
-    def test_stopbefore_empty(self):
-        args = parse_args(self.config, ["-h", "a"])
-        self.assertIsNone(args.stop_before)
-
-    def test_stopbefore_host(self):
-        args = parse_args(self.config, ["-h", "a", "--stopbefore", "host"])
-        self.assertEqual(args.stop_before, "host")
-
     # --list
     def test_list_default(self):
         args = parse_args(self.config, ["-h", "a"])
@@ -227,18 +209,6 @@ class TestArgumentReconstruction(unittest.TestCase):
         args = parse_args(self.config, ["-h", "host", "-h", "host2"])
         canonical = construct_canonical_commandline(self.config, args)
         self.assertEqual("-h host host2 --parallel=5 --timeout=60", canonical)
-
-    def test_startat(self):
-        args = parse_args(self.config, ["-h", "host", "--startat", "host"])
-        canonical = construct_canonical_commandline(self.config, args)
-        self.assertEqual(
-            "-h host --startat=host --parallel=5 --timeout=60", canonical)
-
-    def test_stopbefore(self):
-        args = parse_args(self.config, ["-h", "host", "--stopbefore", "host"])
-        canonical = construct_canonical_commandline(self.config, args)
-        self.assertEqual(
-            "-h host --stopbefore=host --parallel=5 --timeout=60", canonical)
 
     def test_parallel(self):
         args = parse_args(self.config, ["-h", "host", "--parallel", "1"])

--- a/tests/frontends.py
+++ b/tests/frontends.py
@@ -17,7 +17,7 @@ class TestFrontends(unittest.TestCase):
                 result={'components': {'foo': {'abcdef': 1}}},
             ),
         ]
-        host_results = {host: {'status': "success", 'results': results}}
+        host_results = {host: {'status': "complete", 'output': results}}
 
         # Generate Report
         report = generate_component_report(host_results)
@@ -44,7 +44,7 @@ class TestFrontends(unittest.TestCase):
                 result={'components': {'foo': {'abcdef': 1}}},
             ),
         ]
-        host_results = {host: {'status': "success", 'results': results}}
+        host_results = {host: {'status': "complete", 'output': results}}
 
         # Generate Report
         report = generate_component_report(host_results)
@@ -67,7 +67,7 @@ class TestFrontends(unittest.TestCase):
                 result={},
             ),
         ]
-        host_results = {host: {'status': "success", 'results': results}}
+        host_results = {host: {'status': "complete", 'output': results}}
 
         # Generate Report
         report = generate_component_report(host_results)
@@ -85,8 +85,8 @@ class TestFrontends(unittest.TestCase):
             ),
         ]
         host_results = {
-            Host.from_hostname('test'): {'status': "success", 'results': results},
-            Host.from_hostname('test-2'): {'status': "success", 'results': results},
+            Host.from_hostname('test'): {'status': "complete", 'output': results},
+            Host.from_hostname('test-2'): {'status': "complete", 'output': results},
         }
 
         # Generate Report

--- a/tests/hostlist.py
+++ b/tests/hostlist.py
@@ -6,7 +6,6 @@ from rollingpin.hostlist import (
     parse_aliases,
     resolve_alias,
     resolve_hostlist,
-    restrict_hostlist,
     UnresolvableAliasError,
     UnresolvableHostRefError,
 )
@@ -91,37 +90,3 @@ class TestHostListResolution(unittest.TestCase):
             "bad_alias": "d",
         })
         self.assertEqual(hostlist, [a])
-
-
-class TestHostListRestriction(unittest.TestCase):
-
-    def setUp(self):
-        self.hostlist = map(MockHost, ["a", "b", "c", "d", "e", "f"])
-
-    def test_empty(self):
-        hostlist = restrict_hostlist([], None, None)
-        self.assertEqual(hostlist, [])
-
-    def test_invalid_startat(self):
-        with self.assertRaises(HostSelectionError):
-            restrict_hostlist([], "a", None)
-
-    def test_invalid_stopbefore(self):
-        with self.assertRaises(HostSelectionError):
-            restrict_hostlist([], None, "a")
-
-    def test_startat(self):
-        hostlist = restrict_hostlist(self.hostlist, "c", None)
-        self.assertEqual(hostlist, self.hostlist[2:])
-
-    def test_stopbefore(self):
-        hostlist = restrict_hostlist(self.hostlist, None, "c")
-        self.assertEqual(hostlist, self.hostlist[:2])
-
-    def test_startat_and_stopbefore(self):
-        hostlist = restrict_hostlist(self.hostlist, "c", "e")
-        self.assertEqual(hostlist, self.hostlist[2:-2])
-
-    def test_stopbefore_before_startat(self):
-        hostlist = restrict_hostlist(self.hostlist, "e", "c")
-        self.assertEqual(hostlist, [])


### PR DESCRIPTION
The goal of this PR is to rework the UI during deploys to encourage developers to follow our best-practice deploy patterns. It's not meant to completely educate a new developer on how to do deploys properly without further training/context, but instead to remind them on every deploy. 

This also reworks how we organize the hostlist. There's now an explicit canary selection step which pulls one of each pool of hosts into the front of the list in order of largest pool descending. This ensures that we get complete coverage without overdoing the larger groups, while biasing towards catching major errors on high-capacity pools rather than small ones.

There are a bunch of other commits in the leadup here that are mostly about getting the dev environment into a sane state so people can play with this meaningfully. The real guts are in "Encode a safe and reasonable deploy process in user prompts" and "Rejigger host selection for a more suitable canary list".

The upshot of this is that the best way to get a feel for this is to try it out! Clone down the repo, checkout this branch, `vagrant up` and play with `rollout`. 