### PR TITLE
Send salon name in harold requests

### DIFF
--- a/example_profile.ini
+++ b/example_profile.ini
@@ -18,5 +18,6 @@ default-restart = all
 [harold]
 ; per profile override of the '[harold]' section in the primary config (see the
 ; configuration there)
-base-url = http://example.com/
-secret =
+base-url = http://harold.local:8888/
+hmac-secret =
+salon = example-salon

--- a/rollingpin/main.py
+++ b/rollingpin/main.py
@@ -54,6 +54,7 @@ CONFIG_SPEC = {
     "harold": OptionalSection({
         "base-url": Option(str, default=None),
         "hmac-secret": Option(str, default=None),
+        "salon": Option(str, default=None),
     }),
 
     "graphite": OptionalSection({


### PR DESCRIPTION
This allows a single harold instance to figure out which salon a deploy
is managed by.