### PR TITLE
elasticsearch: don't json load doc id on failure

### DIFF
--- a/rollingpin/elasticsearch.py
+++ b/rollingpin/elasticsearch.py
@@ -148,7 +148,8 @@ class ElasticSearchNotifier(object):
         if response.code != 201:
             self.logger.error('Could not store deploy metadata.  '
                               'Got response %s', body)
-        self.deploy_annotation_id = json.loads(body).get('_id', '')
+        else:
+            self.deploy_annotation_id = json.loads(body).get('_id', '')
 
     @inlineCallbacks
     def on_deploy_abort(self, reason):

--- a/rollingpin/elasticsearch.py
+++ b/rollingpin/elasticsearch.py
@@ -47,6 +47,7 @@ class ElasticSearchNotifier(object):
         self.profile = profile
         self.endpoint = "https://%s/%s/%s" % (base_url, index, index_type)
         self.components = components
+        self.deploy_annotation_id = None
 
     def index_doc(self, doc):
         """ Index a document in Elasticsearch


### PR DESCRIPTION
This addresses the issue where ES would be down and
not return a doc id, but we still attempted to read
the returned response even though the response code
was not valid