### PR TITLE
Swap Hippo Host name lookups

### DIFF
--- a/rollingpin/hostsources/hippo.py
+++ b/rollingpin/hostsources/hippo.py
@@ -44,10 +44,10 @@ class HippoHostSource(HostSource):
         host_info = json.loads(host_json)
         tags = host_info["properties"]["tags"]
         try:
-            hostname = tags["Name"]
+            hostname = tags["HostClass"] + instance_id[1:]
         except KeyError:
             try:
-                hostname = tags["HostClass"] + instance_id[1:]
+                hostname = tags["Name"]
             except KeyError:
                 hostname = instance_id
 


### PR DESCRIPTION
Recently r2 moved from numbered "app-*" names
to "r2-app" and now sets a Hostclass, so the
Hostclass + instance-ID naming scheme should
now be propagated to all services and can
be the rollingpin default for the Hippo hostsource.

:eyeglasses: @alienth @spladug 