### PR TITLE
Print host address when `list`ing.

### DIFF
--- a/rollingpin/main.py
+++ b/rollingpin/main.py
@@ -215,7 +215,7 @@ def _main(reactor, *raw_args):
     # execute
     if args.list_hosts:
         for host in hosts:
-            print host.name
+            print host.name, host.address
     else:
         deployer = Deployer(
             config,


### PR DESCRIPTION
:eyeglasses: @spladug @ckwang8128 

I've had to do this indirectly many times, so getting it directly would be handy.

Main concern would be if we have existing scripts which depend upon the output of `--list`.