### PR TITLE
Wavefront annotations

### DIFF
--- a/example.ini
+++ b/example.ini
@@ -81,6 +81,11 @@ type = deploy_events
 ; https://twistedmatrix.com/documents/14.0.0/core/howto/endpoints.html#clients
 endpoint =
 
+[wavefront]
+; if configured, a Wavefront Event will be generated for the deploy.
+endpoint =
+api_key =
+
 [aliases]
 ; glob patterns for aliasing groups of servers
 all = %(common)s %(medium)s %(rare)s singular

--- a/rollingpin/elasticsearch.py
+++ b/rollingpin/elasticsearch.py
@@ -5,33 +5,10 @@ import logging
 import time
 
 from twisted.internet import reactor
-from twisted.internet.defer import inlineCallbacks, succeed
+from twisted.internet.defer import inlineCallbacks
 from twisted.web.client import Agent, readBody
 from twisted.web.http_headers import Headers
-from twisted.web.iweb import IBodyProducer
-from zope.interface import implements
-from .utils import swallow_exceptions
-
-
-class JSONBodyProducer(object):
-    implements(IBodyProducer)
-
-    def __init__(self, data):
-        self.length = len(data)
-        self.body = data
-
-    def startProducing(self, consumer):
-        consumer.write(self.body)
-        return succeed(None)
-
-    def pauseProducing(self):
-        pass
-
-    def stopProducing(self):
-        pass
-
-    def getBody(self):
-        return self.body
+from .utils import JSONBodyProducer, swallow_exceptions
 
 
 class ElasticSearchNotifier(object):

--- a/rollingpin/main.py
+++ b/rollingpin/main.py
@@ -35,6 +35,7 @@ from .graphite import enable_graphite_notifications
 from .log import log_to_file
 from .providers import get_provider, UnknownProviderError
 from .utils import interleaved, b36encode
+from .wavefront import enable_wavefront_notifications
 
 
 PROFILE_DIRECTORY = "/etc/rollingpin.d/"
@@ -65,6 +66,11 @@ CONFIG_SPEC = {
         "endpoint": Option(str, default=None),
         "index": Option(str, default=None),
         "type": Option(str, default=None),
+    }),
+
+    "wavefront": OptionalSection({
+        "endpoint": Option(str, default=None),
+        "api_key": Option(str, default=None),
     }),
 
     "hostsource": {
@@ -205,6 +211,10 @@ def _main(reactor, *raw_args):
 
     if config["elasticsearch"]["endpoint"]:
         enable_elastic_search_notifications(
+            config, event_bus, args.components, hosts, args.original, word, profile)
+
+    if config["wavefront"]["endpoint"] and config["wavefront"]["api_key"]:
+        enable_wavefront_notifications(
             config, event_bus, args.components, hosts, args.original, word, profile)
 
     if not args.dangerously_fast and os.isatty(sys.stdout.fileno()):

--- a/rollingpin/utils.py
+++ b/rollingpin/utils.py
@@ -10,7 +10,10 @@ from twisted.internet.defer import (
     gatherResults,
     inlineCallbacks,
     returnValue,
+    succeed,
 )
+from twisted.web.iweb import IBodyProducer
+from zope.interface import implements
 
 
 MAX_PARALLELISM = 50
@@ -99,3 +102,24 @@ def b36encode(number, alphabet='0123456789abcdefghijklmnopqrstuvwxyz'):
         base36 = alphabet[i] + base36
 
     return sign + base36
+
+
+class JSONBodyProducer(object):
+    implements(IBodyProducer)
+
+    def __init__(self, data):
+        self.length = len(data)
+        self.body = data
+
+    def startProducing(self, consumer):
+        consumer.write(self.body)
+        return succeed(None)
+
+    def pauseProducing(self):
+        pass
+
+    def stopProducing(self):
+        pass
+
+    def getBody(self):
+        return self.body

--- a/rollingpin/wavefront.py
+++ b/rollingpin/wavefront.py
@@ -1,0 +1,121 @@
+"""Reports deploy metadata to Wavefront"""
+import getpass
+import json
+import logging
+import time
+import urllib
+
+from twisted.internet import reactor
+from twisted.internet.defer import inlineCallbacks
+from twisted.web.client import Agent, readBody
+from twisted.web.http_headers import Headers
+from .utils import JSONBodyProducer, swallow_exceptions
+
+
+class WavefrontNotifier(object):
+    def __init__(self, config, components, hosts, command_line, word, profile):
+        self.logger = logging.getLogger(__name__)
+        self.endpoint = config['wavefront']['endpoint']
+        self.hosts = hosts
+        self.command_line = command_line
+        self.deploy_name = word
+        self.profile = profile
+        self.api_key = config['wavefront']['api_key']
+        self.components = components
+        self.deploy_event_id = None
+        self.deploy_start_time = None
+        self.deploy_event = {
+            "name": "%s Deploy" % self.profile,
+            "annotations": {
+                "severity": "info",
+                "type": "Rollingpin Deploy",
+                "details": "deploy-name=%s" % self.deploy_name,
+            },
+            "tags" : [
+                "%s.deploy" % self.profile,
+            ],
+        }
+
+    def open_deploy_event(self, event_info):
+        with swallow_exceptions('wavefront', self.logger):
+            agent = Agent(reactor)
+            body = JSONBodyProducer(json.dumps(event_info))
+            return agent.request(
+                'POST',
+                '%s/api/v2/event' % self.endpoint,
+                Headers({
+                    'Authorization': ['Bearer %s' % self.api_key],
+                    'Content-Type': ['application/JSON'],
+                }),
+                body,
+            )
+
+    def update_deploy_event(self, event_info):
+        with swallow_exceptions('wavefront', self.logger):
+            agent = Agent(reactor)
+            body = JSONBodyProducer(json.dumps(event_info))
+            return agent.request(
+                'PUT',
+                '%s/api/v2/event/%s' % (self.endpoint, urllib.quote(self.deploy_event_id)),
+                Headers({
+                    'Authorization': ['Bearer %s' % self.api_key],
+                    'Content-Type': ['application/JSON'],
+                }),
+                body,
+            )
+
+    def deploy_start_event(self):
+        """ Return Wavefront-conformant JSON indicating start of deploy.
+        """
+        timestamp_in_milliseconds = int(time.time()) * 1000
+        self.deploy_start_time = timestamp_in_milliseconds
+        self.deploy_event['startTime'] = self.deploy_start_time
+        return self.deploy_event
+
+    def deploy_abort_event(self, reason):
+        """ Return Wavefront-conformant JSON to update deploy event
+        indicating deploy was aborted.
+        """
+        timestamp_in_milliseconds = int(time.time()) * 1000
+        self.deploy_event['annotations']['severity'] = 'warn'
+        self.deploy_event['tags'].append("%s.deploy.aborted" % self.profile)
+        self.deploy_event['endTime'] = timestamp_in_milliseconds
+        return self.deploy_event
+
+    def deploy_end_event(self):
+        """ Return Wavefront-conformant JSON to update event
+        indicating deploy was completed.
+        """
+        timestamp_in_milliseconds = int(time.time()) * 1000
+        self.deploy_event['endTime'] = timestamp_in_milliseconds
+        return self.deploy_event
+
+    @inlineCallbacks
+    def on_deploy_start(self):
+        # Store initial event ID so we can update as deploy continues
+        response = yield self.open_deploy_event(self.deploy_start_event())
+        body = yield readBody(response)
+        if response.code != 200:
+            self.logger.error('Could not write Wavefront Event. '
+                              ' Got response %s', body)
+        self.deploy_event_id = json.loads(body)['response']['id']
+
+    @inlineCallbacks
+    def on_deploy_abort(self, reason):
+        yield self.update_deploy_event(self.deploy_abort_event(reason))
+
+    @inlineCallbacks
+    def on_deploy_end(self):
+        yield self.update_deploy_event(self.deploy_end_event())
+
+
+def enable_wavefront_notifications(config, event_bus, components, hosts,
+                                   command_line, word, profile):
+
+    notifier = WavefrontNotifier(
+        config, components, hosts, command_line, word, profile)
+    event_bus.register({
+        "deploy.begin": notifier.on_deploy_start,
+        "deploy.abort": notifier.on_deploy_abort,
+        "deploy.end": notifier.on_deploy_end,
+    })

--- a/tests/wavefront.py
+++ b/tests/wavefront.py
@@ -1,0 +1,85 @@
+import json
+import unittest
+from mock import MagicMock, patch
+
+from rollingpin.wavefront import WavefrontNotifier
+
+
+@patch('time.time', MagicMock(return_value=1))
+class TestWavefrontNotifier(unittest.TestCase):
+
+    def setUp(self):
+        self.components = ["service-1", "service-2"]
+        self.hosts = ["host1", "host2", "host3"]
+        self.command = "somerolloutcommand"
+        self.deploy_word = "fat-rabbit"
+        self.config = {
+            "wavefront": {
+                "endpoint": "https://test.wavefront.com",
+                "api_key": "testkey"
+            }
+        }
+        self.profile = "example-profile"
+        self.wf_notifier_args = [
+            self.config,
+            self.components,
+            self.hosts,
+            self.command,
+            self.deploy_word,
+            self.profile,
+        ]
+        self.wf_notifier = WavefrontNotifier(*self.wf_notifier_args)
+
+    @patch('rollingpin.wavefront.reactor', MagicMock())
+    def test_open_event(self):
+        agent = MagicMock()
+        event = {'hello': 'world'}
+        patch_target = 'rollingpin.wavefront.Agent'
+        with patch(patch_target, MagicMock(return_value=agent)):
+            self.wf_notifier.open_deploy_event(event)
+
+        agent.request.assert_called()
+        args = agent.request.call_args[0]
+        self.assertEquals(len(args), 4)
+        method, endpoint, headers, body = args
+        self.assertEquals(method, 'POST')
+        self.assertEquals(endpoint, 'https://test.wavefront.com/api/v2/event')
+        header_list = [{key: value}
+                       for key, value in headers.getAllRawHeaders()]
+        self.assertEquals(
+            header_list,
+            [
+                {'Content-Type': ['application/JSON']},
+                {'Authorization': ['Bearer testkey']},
+            ]
+        )
+        self.assertEquals(body.getBody(), json.dumps(event))
+
+    def test_deploy_abort_event(self):
+        reason = "testabort"
+        deploy_abort_event = self.wf_notifier.deploy_abort_event(reason)
+        expected_deploy_abort_event = {
+            'annotations': {
+                'details': 'deploy-name=fat-rabbit',
+                'severity': 'warn',
+                'type': 'Rollingpin Deploy'
+            },
+            'endTime': 1000,
+            'name': 'example-profile Deploy',
+            'tags': ['example-profile.deploy', 'example-profile.deploy.aborted'],
+        }
+        self.assertEquals(deploy_abort_event, expected_deploy_abort_event)
+
+    def test_deploy_end_event(self):
+        deploy_end_event = self.wf_notifier.deploy_end_event()
+        expected_deploy_end_event = {
+            'annotations': {
+                'details': 'deploy-name=fat-rabbit',
+                'severity': 'info',
+                'type': 'Rollingpin Deploy'
+            },
+            'endTime': 1000,
+            'name': 'example-profile Deploy',
+            'tags': ['example-profile.deploy']
+        }
+        self.assertEquals(deploy_end_event, expected_deploy_end_event)


### PR DESCRIPTION
This adds [Wavefront Event](https://docs.wavefront.com/events.html) creation functionality to the Rollingpin deploy process. One Event is created per deploy, with Event closing happening on finished or aborted deploys. Deploy name information is provided in details, and the deploy profile is captured in the name of the event. 

![image](https://user-images.githubusercontent.com/894688/50183798-fdb8b980-02c7-11e9-91f1-9fbc40fcf9d6.png)

:eyeglasses: @spladug @foklepoint 
