### PR TITLE
Skip restart if deploy script reports no code changes

### DIFF
--- a/example.ini
+++ b/example.ini
@@ -45,6 +45,7 @@ hosts = common-01
         rare-01
         rare-02
         rare-03
+        noop-01
         singular
 
 [transport]
@@ -83,7 +84,8 @@ endpoint =
 
 [aliases]
 ; glob patterns for aliasing groups of servers
-all = %(common)s %(medium)s %(rare)s singular
+all = %(common)s %(medium)s %(rare)s %(noop)s singular
 common = common-*
 medium = medium-*
 rare = rare-*
+noop = noop-*

--- a/rollingpin/args.py
+++ b/rollingpin/args.py
@@ -189,19 +189,21 @@ def _add_deploy_arguments(config, parser):
 
 def _parse_command_args(command_args):
     rv = []
-    for (command, arg) in command_args:
-        if command == "synchronize":
-            rv.append(commands.SynchronizeCommand([arg]))
-        elif command == "deploy":
-            rv.append(commands.DeployCommand([arg]))
-        elif command == "build":
-            rv.append(commands.BuildCommand([arg]))
-        elif command == "restart":
-            rv.append(commands.RestartCommand([arg]))
-        elif command == "wait-until-components-ready":
-            rv.append(commands.WaitUntilComponentsReadyCommand([arg]))
+    for command in command_args:
+        (cmd_name, args) = (command[0], command[1:])
+
+        if cmd_name == "synchronize":
+            rv.append(commands.SynchronizeCommand(args))
+        elif cmd_name == "deploy":
+            rv.append(commands.DeployCommand(args))
+        elif cmd_name == "build":
+            rv.append(commands.BuildCommand(args))
+        elif cmd_name == "restart":
+            rv.append(commands.RestartCommand(args))
+        elif cmd_name == "wait-until-components-ready":
+            rv.append(commands.WaitUntilComponentsReadyCommand(args))
         else:
-            raise NotImplementedError
+            rv.append(commands.GenericCommand(cmd_name, args))
 
     return rv
 
@@ -278,7 +280,7 @@ def construct_canonical_commandline(config, args):
             arg_list.extend(("-r", command.args[0]))
         else:
             arg_list.append("-c")
-            arg_list.extend(command.name)
+            arg_list.extend(command.cmdline())
 
     return " ".join(arg_list)
 

--- a/rollingpin/args.py
+++ b/rollingpin/args.py
@@ -231,17 +231,18 @@ def parse_args(config, raw_args=None, profile=None):
 
     args = parser.parse_args(args=raw_args)
 
+    args.commands = _parse_command_args(args.commands)
+
     if not args.restart:
         default_restart = config["deploy"].get("default-restart", [])
         if not isinstance(default_restart, list):
             default_restart = [default_restart]
 
-        args.restart = default_restart
-
-    args.commands = _parse_command_args(args.commands)
-
-    for target in args.restart:
-        args.commands.append(commands.RestartCommand(args=[target], explicit=True))
+        for target in default_restart:
+            args.commands.append(commands.RestartCommand(args=[target], explicit=False))
+    else:
+        for target in args.restart:
+            args.commands.append(commands.RestartCommand(args=[target], explicit=True))
 
     if args.components == ["none"]:
         args.components = []

--- a/rollingpin/args.py
+++ b/rollingpin/args.py
@@ -2,7 +2,7 @@ import argparse
 import os
 import sys
 
-import .commands
+import rollingpin.commands as commands
 
 
 COMMANDS_BY_NAME = {
@@ -199,7 +199,7 @@ def _add_deploy_arguments(config, parser):
 def _parse_command_args(command_args):
     rv = []
     for command in command_args:
-        (cmd_name, args) = (command[0], command[1:])
+        (cmd_name, args) = command[0], command[1:]
 
         if cmd_name in COMMANDS_BY_NAME:
             cmd_class = COMMANDS_BY_NAME[cmd_name]
@@ -238,10 +238,10 @@ def parse_args(config, raw_args=None, profile=None):
 
         args.restart = default_restart
 
+    args.commands = _parse_command_args(args.commands)
+
     for target in args.restart:
         args.commands.append(commands.RestartCommand([target]))
-
-    args.commands = _parse_command_args(args.commands)
 
     if args.components == ["none"]:
         args.components = []

--- a/rollingpin/args.py
+++ b/rollingpin/args.py
@@ -235,7 +235,7 @@ def parse_args(config, raw_args=None, profile=None):
         args.restart = default_restart
 
     for target in args.restart:
-        args.commands.append(["restart", target])
+        args.commands.append(commands.RestartCommand([target]))
 
     args.commands = _parse_command_args(args.commands)
 
@@ -299,7 +299,7 @@ def build_action_summary(config, args):
             summary_points.append(
                 "Restart `{}` applications.".format(command.args[0]))
         else:
-            summary_points.append("Run the `{}` command.".format(" ".join(command.name)))
+            summary_points.append("Run the `{}` command.".format(" ".join(command.name())))
 
     summary_details = []
 

--- a/rollingpin/args.py
+++ b/rollingpin/args.py
@@ -303,7 +303,7 @@ def build_action_summary(config, args):
             summary_points.append(
                 "Restart `{}` applications.".format(command.args[0]))
         else:
-            summary_points.append("Run the `{}` command.".format(" ".join(command.name())))
+            summary_points.append("Run the `{}` command.".format(" ".join(command.name)))
 
     summary_details = []
 

--- a/rollingpin/args.py
+++ b/rollingpin/args.py
@@ -2,7 +2,16 @@ import argparse
 import os
 import sys
 
-import commands
+import .commands
+
+
+COMMANDS_BY_NAME = {
+    "synchronize": commands.SynchronizeCommand,
+    "deploy": commands.DeployCommand,
+    "build": commands.BuildCommand,
+    "restart": commands.RestartCommand,
+    "wait-until-components-ready": commands.WaitUntilComponentsReadyCommand,
+}
 
 
 class ExtendList(argparse.Action):
@@ -192,18 +201,13 @@ def _parse_command_args(command_args):
     for command in command_args:
         (cmd_name, args) = (command[0], command[1:])
 
-        if cmd_name == "synchronize":
-            rv.append(commands.SynchronizeCommand(args))
-        elif cmd_name == "deploy":
-            rv.append(commands.DeployCommand(args))
-        elif cmd_name == "build":
-            rv.append(commands.BuildCommand(args))
-        elif cmd_name == "restart":
-            rv.append(commands.RestartCommand(args))
-        elif cmd_name == "wait-until-components-ready":
-            rv.append(commands.WaitUntilComponentsReadyCommand(args))
+        if cmd_name in COMMANDS_BY_NAME:
+            cmd_class = COMMANDS_BY_NAME[cmd_name]
+            cmd = cmd_class(args)
         else:
-            rv.append(commands.GenericCommand(cmd_name, args))
+            cmd = commands.GenericCommand(cmd_name, args)
+
+        rv.append(cmd)
 
     return rv
 

--- a/rollingpin/args.py
+++ b/rollingpin/args.py
@@ -241,7 +241,7 @@ def parse_args(config, raw_args=None, profile=None):
     args.commands = _parse_command_args(args.commands)
 
     for target in args.restart:
-        args.commands.append(commands.RestartCommand([target]))
+        args.commands.append(commands.RestartCommand(args=[target], explicit=True))
 
     if args.components == ["none"]:
         args.components = []
@@ -303,7 +303,7 @@ def build_action_summary(config, args):
             summary_points.append(
                 "Restart `{}` applications.".format(command.args[0]))
         else:
-            summary_points.append("Run the `{}` command.".format(" ".join(command.name)))
+            summary_points.append("Run the `{}` command.".format(" ".join(command.cmdline())))
 
     summary_details = []
 

--- a/rollingpin/commands.py
+++ b/rollingpin/commands.py
@@ -1,21 +1,9 @@
-from abc import ABCMeta, abstractproperty
-
-
 class Command(object):
-    __metaclass__ = ABCMeta
-
     CONTINUE = 1
     SKIP_REMAINING = 2
 
     def __init__(self, args=None):
-        if args is None:
-            self._args = []
-        else:
-            self._args = args
-
-    @abstractproperty
-    def name(self):
-        raise NotImplementedError
+        self._args = args or []
 
     @property
     def args(self):
@@ -30,28 +18,23 @@ class Command(object):
     def check_result(self, result):
         return Command.CONTINUE
 
-    def __str__(self):
-        return "Command(name={}, args={})".format(self.name(), self._args)
-
     def __repr__(self):
-        return self.__str__()
+        return "Command(name={}, args={})".format(self.name(), self._args)
 
 
 class SynchronizeCommand(Command):
-    def name(self):
-        return "synchronize"
+    name = "synchronize"
 
 
 class DeployCommand(Command):
-    def name(self):
-        return "deploy"
+    name = "deploy"
 
     def check_result(self, result):
         # For backwards compatibility
         if not result:
             return Command.CONTINUE
 
-        changed = any([result[v] is not False for v in result])
+        changed = any(result[v] is not False for v in result)
         if not changed:
             return Command.SKIP_REMAINING
         else:
@@ -59,24 +42,18 @@ class DeployCommand(Command):
 
 
 class BuildCommand(Command):
-    def name(self):
-        return "build"
+    name = "build"
 
 
 class RestartCommand(Command):
-    def name(self):
-        return "restart"
+    name = "restart"
 
 
 class WaitUntilComponentsReadyCommand(Command):
-    def name(self):
-        return "wait-until-components-ready"
+    name = "wait-until-components-ready"
 
 
 class GenericCommand(Command):
     def __init__(self, name, args=None):
-        self._name = name
+        self.name = name
         super(GenericCommand, self).__init__(args)
-
-    def name(self):
-        return self._name

--- a/rollingpin/commands.py
+++ b/rollingpin/commands.py
@@ -39,7 +39,7 @@ class DeployCommand(Command):
         if not result:
             return Command.CONTINUE
 
-        changed = any(result[v] is DeployCommand.REPO_CHANGED for v in result)
+        changed = any(result[v] == DeployCommand.REPO_CHANGED for v in result)
         if not changed:
             return Command.SKIP_REMAINING
         else:

--- a/rollingpin/commands.py
+++ b/rollingpin/commands.py
@@ -30,6 +30,12 @@ class Command(object):
     def check_result(self, result):
         return Command.CONTINUE
 
+    def __str__(self):
+        return "Command(name={}, args={})".format(self.name(), self._args)
+
+    def __repr__(self):
+        return self.__str__()
+
 
 class SynchronizeCommand(Command):
     def name(self):

--- a/rollingpin/commands.py
+++ b/rollingpin/commands.py
@@ -13,13 +13,13 @@ class Command(object):
         self._args.append(arg)
 
     def cmdline(self):
-        return [self.name()] + self._args
+        return [self.name] + self._args
 
     def check_result(self, result):
         return Command.CONTINUE
 
     def __repr__(self):
-        return "Command(name={}, args={})".format(self.name(), self._args)
+        return "Command(name={}, args={})".format(self.name, self._args)
 
 
 class SynchronizeCommand(Command):
@@ -27,6 +27,10 @@ class SynchronizeCommand(Command):
 
 
 class DeployCommand(Command):
+    # Flag constants for deploy return value
+    REPO_UNCHANGED = "repo_unchanged"
+    REPO_CHANGED = "repo_changed"
+
     name = "deploy"
 
     def check_result(self, result):
@@ -34,7 +38,7 @@ class DeployCommand(Command):
         if not result:
             return Command.CONTINUE
 
-        changed = any(result[v] is not False for v in result)
+        changed = any(result[v] is DeployCommand.REPO_CHANGED for v in result)
         if not changed:
             return Command.SKIP_REMAINING
         else:

--- a/rollingpin/commands.py
+++ b/rollingpin/commands.py
@@ -41,8 +41,11 @@ class DeployCommand(Command):
         return "deploy"
 
     def check_result(self, result):
-        changed = any([result[v] is not False for v in result])
+        # For backwards compatibility
+        if not result:
+            return Command.CONTINUE
 
+        changed = any([result[v] is not False for v in result])
         if not changed:
             return Command.SKIP_REMAINING
         else:

--- a/rollingpin/commands.py
+++ b/rollingpin/commands.py
@@ -2,7 +2,8 @@ class Command(object):
     CONTINUE = 1
     SKIP_REMAINING = 2
 
-    def __init__(self, args=None):
+    def __init__(self, args=None, explicit=False):
+        self.explicit = explicit
         self._args = args or []
 
     @property
@@ -58,6 +59,8 @@ class WaitUntilComponentsReadyCommand(Command):
 
 
 class GenericCommand(Command):
+
     def __init__(self, name, args=None):
         self.name = name
-        super(GenericCommand, self).__init__(args)
+        # Generic commands can only be added explicitly from the commandline.
+        super(GenericCommand, self).__init__(args=args, explicit=True)

--- a/rollingpin/commands.py
+++ b/rollingpin/commands.py
@@ -1,0 +1,50 @@
+from abc import ABCMeta, abstractproperty
+
+
+class Command(object):
+    __metaclass__ = ABCMeta
+
+    def __init__(self, args=None):
+        if args is None:
+            self._args = []
+        else:
+            self._args = args
+
+    def add_argument(self, arg):
+        self._args.append(arg)
+
+    @abstractproperty
+    def name(self):
+        raise NotImplementedError
+
+    @property
+    def args(self):
+        return self._args
+
+    def cmdline(self):
+        return [self.name()] + self._args
+
+
+class SynchronizeCommand(Command):
+    def name(self):
+        return "synchronize"
+
+
+class DeployCommand(Command):
+    def name(self):
+        return "deploy"
+
+
+class BuildCommand(Command):
+    def name(self):
+        return "build"
+
+
+class RestartCommand(Command):
+    def name(self):
+        return "restart"
+
+
+class WaitUntilComponentsReadyCommand(Command):
+    def name(self):
+        return "wait-until-components-ready"

--- a/rollingpin/deploy.py
+++ b/rollingpin/deploy.py
@@ -20,7 +20,7 @@ from .commands import (
     WaitUntilComponentsReadyCommand
 )
 from .hostsources import Host
-from .transports import TransportError, ExecutionTimeout
+from .transports import TransportError
 from .utils import sleep
 
 

--- a/rollingpin/deploy.py
+++ b/rollingpin/deploy.py
@@ -96,6 +96,7 @@ class Deployer(object):
         try:
             log.info("connecting")
             connection = yield self.transport.connect_to(host.address)
+            command_queue = commands.copy()
             while command_queue:
                 command = command_queue.pop(0)
                 log.info(" ".join(command.cmdline()))

--- a/rollingpin/deploy.py
+++ b/rollingpin/deploy.py
@@ -99,14 +99,14 @@ class Deployer(object):
             for command in commands:
                 log.info(" ".join(command.cmdline()))
                 yield self.event_bus.trigger(
-                    "host.command", host=host, command=command.name())
+                    "host.command", host=host, command=command.name)
                 result = yield connection.execute(log, command.cmdline(), timeout)
 
-                results.append(DeployResult(command.name(), result))
+                results.append(DeployResult(command.name, result))
 
                 control = command.check_result(result)
                 if control == Command.SKIP_REMAINING:
-                    log.info("{} reported no changes, skipping remaining steps.".format(command.name()))
+                    log.info("{} reported no changes, skipping remaining steps.".format(command.name))
                     break
 
             yield connection.disconnect()

--- a/rollingpin/deploy.py
+++ b/rollingpin/deploy.py
@@ -96,7 +96,7 @@ class Deployer(object):
         try:
             log.info("connecting")
             connection = yield self.transport.connect_to(host.address)
-            command_queue = commands.copy()
+            command_queue = commands[:]
             while command_queue:
                 command = command_queue.pop(0)
                 log.info(" ".join(command.cmdline()))

--- a/rollingpin/deploy.py
+++ b/rollingpin/deploy.py
@@ -17,7 +17,7 @@ from .commands import (
     DeployCommand,
     RestartCommand,
     SynchronizeCommand,
-    WaitUntilComponentsReadyCommand
+    WaitUntilComponentsReadyCommand,
 )
 from .hostsources import Host
 from .transports import TransportError

--- a/rollingpin/deploy.py
+++ b/rollingpin/deploy.py
@@ -96,9 +96,8 @@ class Deployer(object):
         try:
             log.info("connecting")
             connection = yield self.transport.connect_to(host.address)
-            command_queue = commands[::-1]
             while command_queue:
-                command = command_queue.pop()
+                command = command_queue.pop(0)
                 log.info(" ".join(command.cmdline()))
                 yield self.event_bus.trigger(
                     "host.command", host=host, command=command.name)

--- a/rollingpin/transports/mock.py
+++ b/rollingpin/transports/mock.py
@@ -104,6 +104,6 @@ class NoopDeployMockTransportConnection(MockTransportConnection):
         log.debug("MOCK: no local changes detected")
         result = dict()
         for arg in args:
-            result[arg] = False
+            result[arg] = "repo_unchanged"
 
         return succeed(result)

--- a/tests/args.py
+++ b/tests/args.py
@@ -116,31 +116,31 @@ class TestArgumentParsing(unittest.TestCase):
     # -r
     def test_one_restart(self):
         args = parse_args(self.config, ["-h", "a", "-r", "all"])
-        self.assertEqual(args.commands, [["restart", "all"]])
+        self.assertEqual(cmdline(args.commands), [["restart", "all"]])
 
     def test_multi_restart(self):
         args = parse_args(self.config, ["-h", "a", "-r", "all", "-r", "more"])
         self.assertEqual(
-            args.commands, [["restart", "all"], ["restart", "more"]])
+            cmdline(args.commands), [["restart", "all"], ["restart", "more"]])
 
     # -c
     def test_no_commands(self):
         args = parse_args(self.config, ["-h", "a"])
-        self.assertEqual(args.commands, [])
+        self.assertEqual(cmdline(args.commands), [])
 
     def test_simple_command(self):
         args = parse_args(self.config, ["-h", "a", "-c", "test"])
-        self.assertEqual(args.commands, [["test"]])
+        self.assertEqual(cmdline(args.commands), [["test"]])
 
     def test_command_with_args(self):
         args = parse_args(self.config, ["-h", "a", "-c", "test", "args"])
-        self.assertEqual(args.commands, [["test", "args"]])
+        self.assertEqual(cmdline(args.commands), [["test", "args"]])
 
     # mixup
     def test_commands_together(self):
         args = parse_args(
             self.config, ["-h", "a", "-c", "test", "args", "-r", "all"])
-        self.assertEqual(args.commands, [["test", "args"], ["restart", "all"]])
+        self.assertEqual(cmdline(args.commands), [["test", "args"], ["restart", "all"]])
 
 
 class TestProfileArguments(unittest.TestCase):
@@ -170,7 +170,7 @@ class TestProfileArguments(unittest.TestCase):
         full_args = parse_args(self.config, args)
 
         self.assertEqual(profile_info.profile, "foo")
-        self.assertEqual(full_args.commands, [["test"]])
+        self.assertEqual(cmdline(full_args.commands), [["test"]])
 
     def test_invalid_profile(self):
         args = ["bad", "-h", "a"]
@@ -287,3 +287,8 @@ class TestArgumentReconstruction(unittest.TestCase):
         canonical = construct_canonical_commandline(self.config, args)
         self.assertEqual(
             "-h host --parallel=5 --timeout=60 --verbose", canonical)
+
+
+# Helper
+def cmdline(cmds):
+    return [cmd.cmdline() for cmd in cmds]


### PR DESCRIPTION
essentially:

* The deploy stage can now return a dictionary of
```{
   "component@hash": true/false,
    ....
}
```
Determining whether or not that component is safe to skip a restart for.

* If all components have the false bit set, we skip the remaining commands for that host, which will be the restart and wait-for-components commands.

I did a little bit of refactoring for this to avoid dumping more conditional logic into deploy.py --

* I replaced the use of ["command", "args"...] lists with command objects where deploy lifecycle logic can be defined. I'm not super married to this refactor as it doesn't really buy too much right now, but the pattern seems to feel to feel a bit better now that we're starting to add more conditional logic to the deploy flow.
* generalized the mock transport a bit so different behavior can be mocked out.
