### PR TITLE
Initialize factory.state.

### DIFF
--- a/rollingpin/transports/ssh.py
+++ b/rollingpin/transports/ssh.py
@@ -83,6 +83,8 @@ class _ClientTransport(SSHClientTransport):
             error = ConnectError("unable to make a secure connection")
         elif self.factory.state == "AUTHENTICATING":
             error = ConnectError("unable to authenticate")
+        elif self.factory.state == "CONNECTING":
+            error = ConnectError("unable to connect")
         elif self.factory.state == "CONNECTED":
             return
         self.factory.connection_ready.errback(error)
@@ -135,6 +137,7 @@ class SshTransport(Transport):
     @inlineCallbacks
     def connect_to(self, host):
         factory = _ConnectionFactory(self.config, self.key)
+        factory.state = "CONNECTING"
 
         port = self.config["transport"]["port"]
         timeout = self.config["transport"]["timeout"]


### PR DESCRIPTION
After upgrading twisted we're observing failures in prod where no
functions have been called setting `state`.

:eyeglasses: @eaceaser @spladug 