### PR TITLE
Add generic deploy tag

### DIFF
--- a/rollingpin/wavefront.py
+++ b/rollingpin/wavefront.py
@@ -33,6 +33,7 @@ class WavefrontNotifier(object):
             },
             "tags" : [
                 "%s.deploy" % self.profile,
+                "deploy",
             ],
         }
 

--- a/tests/wavefront.py
+++ b/tests/wavefront.py
@@ -66,7 +66,7 @@ class TestWavefrontNotifier(unittest.TestCase):
             },
             'endTime': 1000,
             'name': 'example-profile Deploy',
-            'tags': ['example-profile.deploy', 'example-profile.deploy.aborted'],
+            'tags': ['example-profile.deploy', 'deploy', 'example-profile.deploy.aborted'],
         }
         self.assertEquals(deploy_abort_event, expected_deploy_abort_event)
 
@@ -80,6 +80,6 @@ class TestWavefrontNotifier(unittest.TestCase):
             },
             'endTime': 1000,
             'name': 'example-profile Deploy',
-            'tags': ['example-profile.deploy']
+            'tags': ['example-profile.deploy', 'deploy']
         }
         self.assertEquals(deploy_end_event, expected_deploy_end_event)


### PR DESCRIPTION
Add generic deploy tag. We want to be able to search the 'deploy' tag in wavefront and see all deploy events.