### PR TITLE
Add harold timeout

### DIFF
--- a/rollingpin/harold.py
+++ b/rollingpin/harold.py
@@ -13,6 +13,8 @@ from twisted.web.http_headers import Headers
 
 from .utils import swallow_exceptions
 
+TIMEOUT_SECONDS = 5
+
 
 class FormEncodedBodyProducer(object):
 
@@ -43,7 +45,7 @@ class HaroldWhisperer(object):
         self.secret = config["harold"]["hmac-secret"]
 
         self.connection_pool = HTTPConnectionPool(reactor)
-        self.agent = Agent(reactor, pool=self.connection_pool)
+        self.agent = Agent(reactor, connectTimeout=TIMEOUT_SECONDS, pool=self.connection_pool)
 
     def make_request(self, path, data):
         base_url = urlparse.urlparse(self.base_url)
@@ -63,7 +65,16 @@ class HaroldWhisperer(object):
             "Content-Type": ["application/x-www-form-urlencoded"],
             "X-Hub-Signature": ["sha1=" + body_producer.hash(self.secret)],
         })
-        return self.agent.request("POST", url, headers, body_producer)
+        req = self.agent.request("POST", url, headers, body_producer)
+
+        timeout = reactor.callLater(TIMEOUT_SECONDS, req.cancel())
+
+        def cancel_timeout(n):
+            if timeout.active():
+                timeout.cancel()
+            return n
+        req.addBoth(cancel_timeout)
+        return req
 
 
 class HaroldNotifier(object):


### PR DESCRIPTION
adds a 5 second timeout to harold requests.

When the status API times out (this behavior already existed):
>failed to fetch deploy status: timed out 

When the harold progress event times out (this is new timeout behavior):
> harold: request timed out after 5 seconds (/harold/deploy/progress)